### PR TITLE
Add Angular storefront sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Angular sample
+
+A minimal Angular storefront example lives in [`angular-ecommerce`](angular-ecommerce). It shows how you might start building a Flipkart-like application using Angular components.

--- a/angular-ecommerce/README.md
+++ b/angular-ecommerce/README.md
@@ -1,0 +1,26 @@
+# Angular E-commerce Sample
+
+This folder contains a minimal Angular application that demonstrates the structure of a Flipkart-like storefront. The code is intentionally simple so you can expand on it.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+   (Requires internet access.)
+
+2. Start the development server:
+   ```bash
+   npx ng serve
+   ```
+
+3. Open `http://localhost:4200` in your browser.
+
+## Project structure
+
+- `angular.json` – Angular CLI configuration.
+- `package.json` – dependencies and scripts.
+- `src/` – application source code.
+
+This sample includes components for displaying products and a simple cart placeholder. It is **not** a full e-commerce solution but should help you get started with Angular.

--- a/angular-ecommerce/angular.json
+++ b/angular-ecommerce/angular.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "projects": {
+    "angular-ecommerce": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "tsConfig": "tsconfig.json"
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "angular-ecommerce:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "angular-ecommerce"
+}

--- a/angular-ecommerce/package.json
+++ b/angular-ecommerce/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "angular-ecommerce",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "rxjs": "^7.5.0",
+    "zone.js": "^0.14.0"
+  },
+  "devDependencies": {
+    "@angular/cli": "^17.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/angular-ecommerce/src/app/app.component.ts
+++ b/angular-ecommerce/src/app/app.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <h1>Flipkart Clone</h1>
+    <app-product-list></app-product-list>
+    <app-cart></app-cart>
+  `
+})
+export class AppComponent {}

--- a/angular-ecommerce/src/app/app.module.ts
+++ b/angular-ecommerce/src/app/app.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { ProductListComponent } from './components/product-list.component';
+import { CartComponent } from './components/cart.component';
+
+@NgModule({
+  declarations: [AppComponent, ProductListComponent, CartComponent],
+  imports: [BrowserModule],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/angular-ecommerce/src/app/components/cart.component.ts
+++ b/angular-ecommerce/src/app/components/cart.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-cart',
+  template: `
+    <h2>Cart</h2>
+    <p>Your cart is empty.</p>
+  `
+})
+export class CartComponent {}

--- a/angular-ecommerce/src/app/components/product-list.component.ts
+++ b/angular-ecommerce/src/app/components/product-list.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+
+interface Product {
+  id: number;
+  name: string;
+  price: number;
+}
+
+@Component({
+  selector: 'app-product-list',
+  template: `
+    <h2>Products</h2>
+    <div *ngFor="let product of products">
+      {{ product.name }} - {{ product.price | currency }}
+      <button (click)="addToCart(product)">Add to cart</button>
+    </div>
+  `
+})
+export class ProductListComponent {
+  products: Product[] = [
+    { id: 1, name: 'Sample Product 1', price: 9.99 },
+    { id: 2, name: 'Sample Product 2', price: 19.99 }
+  ];
+
+  addToCart(product: Product) {
+    console.log('Add to cart', product);
+  }
+}

--- a/angular-ecommerce/src/index.html
+++ b/angular-ecommerce/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Flipkart Clone</title>
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/angular-ecommerce/src/main.ts
+++ b/angular-ecommerce/src/main.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/angular-ecommerce/tsconfig.json
+++ b/angular-ecommerce/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"]
+  }
+}


### PR DESCRIPTION
## Summary
- add `angular-ecommerce` folder with a minimal Angular project
- document how to run the Angular sample
- mention new Angular sample in the main README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845f7159f38832ab85028ab5f563801