### PR TITLE
Improve back navigation, refresh section pages, add data export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-i18next": "^15.5.2",
+        "react-markdown": "9.0.1",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
@@ -2975,18 +2976,59 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3038,6 +3080,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3277,6 +3325,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.1.tgz",
@@ -3456,6 +3510,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3615,6 +3679,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3630,6 +3704,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -4088,6 +4202,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4303,7 +4427,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4323,6 +4446,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4330,11 +4466,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4646,6 +4804,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4670,6 +4838,12 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -4980,6 +5154,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -4987,6 +5201,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html2canvas": {
@@ -5088,6 +5312,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/input-otp": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.2.4.tgz",
@@ -5114,6 +5344,30 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -5143,6 +5397,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -5178,6 +5442,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5186,6 +5460,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -5378,6 +5664,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5866,6 +6162,159 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5875,6 +6324,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5917,7 +6808,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6103,6 +6993,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6372,6 +7287,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6499,6 +7424,32 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
+      "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.0",
@@ -6705,6 +7656,39 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -6892,6 +7876,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -6966,6 +7960,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -7017,6 +8025,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -7199,6 +8225,26 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -7281,6 +8327,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -7393,6 +8526,34 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -7677,6 +8838,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ const PediatricianReports = lazy(() => import("./pages/PediatricianReports"));
 const Notifications = lazy(() => import("./pages/Notifications"));
 const BlogArticle = lazy(() => import("./pages/BlogArticle"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword"));
-const AccountSecurity = lazy(() => import("./pages/AccountSecurity"));
+// AccountSecurity merged into /account?tab=security — keep import removed to avoid lazy chunk load
 const EnhancedPasswordReset = lazy(() => import("./components/auth/EnhancedPasswordReset"));
 const Unsubscribe = lazy(() => import("./pages/Unsubscribe"));
 const ChatAssistant = lazy(() => import("./components/chat/ChatAssistant"));
@@ -104,7 +104,7 @@ const App: React.FC = () => {
                       <Route path="/" element={<Index />} />
                       <Route path="/auth" element={<Auth />} />
                       <Route path="/reset-password" element={<EnhancedPasswordReset />} />
-                      <Route path="/security" element={<AccountSecurity />} />
+                      <Route path="/security" element={<Navigate to="/account?tab=security" replace />} />
                       <Route path="/dashboard" element={<Dashboard />} />
                       <Route path="/onboarding" element={<Onboarding />} />
                       <Route path="/track" element={<TrackActivity />} />

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -63,11 +63,6 @@ export const MobileHeader = () => {
     setIsOpen(false);
   };
 
-  const handleSecurity = () => {
-    navigate('/security');
-    setIsOpen(false);
-  };
-
   const handleSubscription = () => {
     navigate('/subscription');
     setIsOpen(false);
@@ -148,20 +143,7 @@ export const MobileHeader = () => {
                     </div>
                   </button>
 
-                  <button 
-                    onClick={handleSecurity}
-                    className="w-full flex items-center space-x-3 p-3 rounded-xl hover:bg-white/80 transition-all duration-200 group touch-manipulation"
-                  >
-                    <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-lg p-2 shadow-sm group-hover:shadow-md transition-shadow">
-                      <Shield className="h-4 w-4 text-white" />
-                    </div>
-                    <div className="flex-1 text-left">
-                      <div className="text-sm font-medium text-foreground">{t('menu.security')}</div>
-                      <div className="text-xs text-muted-foreground">{t('menu.securityDesc')}</div>
-                    </div>
-                  </button>
-
-                  <button 
+                  <button
                     onClick={handleNotifications}
                     className="w-full flex items-center space-x-3 p-3 rounded-xl hover:bg-white/80 transition-all duration-200 group touch-manipulation"
                   >

--- a/src/components/layout/UnifiedHeader.tsx
+++ b/src/components/layout/UnifiedHeader.tsx
@@ -63,11 +63,6 @@ export const UnifiedHeader = () => {
     setIsOpen(false);
   };
 
-  const handleSecurity = () => {
-    navigate('/security');
-    setIsOpen(false);
-  };
-
   const handleSubscription = () => {
     navigate('/subscription');
     setIsOpen(false);
@@ -148,20 +143,7 @@ export const UnifiedHeader = () => {
                     </div>
                   </button>
 
-                  <button 
-                    onClick={handleSecurity}
-                    className="w-full flex items-center space-x-3 p-3 rounded-xl hover:bg-white/80 transition-all duration-200 group touch-manipulation"
-                  >
-                    <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-lg p-2 shadow-sm group-hover:shadow-md transition-shadow">
-                      <Shield className="h-4 w-4 text-white" />
-                    </div>
-                    <div className="flex-1 text-left">
-                      <div className="text-sm font-medium text-foreground">{t('menu.security')}</div>
-                      <div className="text-xs text-muted-foreground">{t('menu.securityDesc')}</div>
-                    </div>
-                  </button>
-
-                  <button 
+                  <button
                     onClick={handleNotifications}
                     className="w-full flex items-center space-x-3 p-3 rounded-xl hover:bg-white/80 transition-all duration-200 group touch-manipulation"
                   >

--- a/src/components/layout/UserProfileDropdown.tsx
+++ b/src/components/layout/UserProfileDropdown.tsx
@@ -46,10 +46,6 @@ export const UserProfileDropdown = () => {
     navigate('/notifications');
   };
 
-  const handleSecurity = () => {
-    navigate('/security');
-  };
-
   const userDisplayName = user?.user_metadata?.full_name || user?.email || 'User';
   const userInitials = userDisplayName
     .split(' ')
@@ -92,11 +88,6 @@ export const UserProfileDropdown = () => {
         <DropdownMenuItem onClick={handleNotifications} className="cursor-pointer">
           <Bell className="h-4 w-4 mr-2" />
           <span>{t('notifications.title')}</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuItem onClick={handleSecurity} className="cursor-pointer">
-          <Shield className="h-4 w-4 mr-2" />
-          <span>Security</span>
         </DropdownMenuItem>
         
         <DropdownMenuItem onClick={handleManageSubscription} className="cursor-pointer">

--- a/src/hooks/useSmartBack.tsx
+++ b/src/hooks/useSmartBack.tsx
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Returns a handler that mimics the browser Back button:
+ * - If there's any in-app history before the current entry, go back one entry.
+ * - Otherwise (direct link, bookmark, fresh tab), fall back to the destination.
+ *
+ * Uses React Router's internal stack index (history.state.idx) instead of
+ * location.key, because the initial entry keeps key='default' even after
+ * navigating forward and back to it — which would incorrectly trigger the
+ * fallback for users who'd been moving between sections.
+ */
+export function useSmartBack(fallback: string = '/dashboard') {
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+    if (idx > 0) {
+      navigate(-1);
+    } else {
+      navigate(fallback);
+    }
+  }, [navigate, fallback]);
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,30 +1,36 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { 
-  User, 
-  Crown, 
-  Settings, 
-  ArrowLeft, 
-  Save, 
+import {
+  User,
+  Crown,
+  Settings,
+  ArrowLeft,
+  Save,
   CreditCard,
   Calendar,
   AlertTriangle,
   Check,
-  Trash2
+  Trash2,
+  Shield,
+  KeyRound,
+  Download,
+  Loader2,
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useSubscription } from '@/hooks/useSubscription';
 import { useToast } from '@/hooks/use-toast';
 import { DesktopHeader } from '@/components/layout/DesktopHeader';
 import { MobileHeader } from '@/components/layout/MobileHeader';
 import { supabase } from '@/integrations/supabase/client';
 import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import { generateUserDataPDF } from '@/utils/generateUserDataExport';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { useProfilePermissions } from '@/hooks/useProfilePermissions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -44,8 +50,24 @@ const Account = () => {
     openCustomerPortal
   } = useSubscription();
   const navigate = useNavigate();
+  const goBack = useSmartBack();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
   const { toast } = useToast();
+
+  const initialTab = (() => {
+    const raw = searchParams.get('tab');
+    return raw === 'subscription' || raw === 'security' ? raw : 'profile';
+  })();
+  const [activeTab, setActiveTab] = useState<string>(initialTab);
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    const next = new URLSearchParams(searchParams);
+    if (value === 'profile') next.delete('tab');
+    else next.set('tab', value);
+    setSearchParams(next, { replace: true });
+  };
 
   const [profile, setProfile] = useState({
     full_name: '',
@@ -55,6 +77,11 @@ const Account = () => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
   const [deleting, setDeleting] = useState(false);
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [changingPassword, setChangingPassword] = useState(false);
+  const [exporting, setExporting] = useState(false);
   
   // Check user role and permissions
   const { activeProfile } = useBabyProfile();
@@ -196,6 +223,90 @@ const Account = () => {
     openCustomerPortal();
   };
 
+  const handleChangePassword = async () => {
+    if (newPassword.length < 8) {
+      toast({
+        title: "Password too short",
+        description: "Choose a password with at least 8 characters.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast({
+        title: "Passwords do not match",
+        description: "Please re-type the same password in both fields.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setChangingPassword(true);
+    try {
+      const { error } = await supabase.auth.updateUser({ password: newPassword });
+      if (error) throw error;
+      toast({
+        title: "Password updated",
+        description: "Your password has been changed successfully.",
+      });
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to update password.",
+        variant: "destructive",
+      });
+    } finally {
+      setChangingPassword(false);
+    }
+  };
+
+  const handleExportData = async () => {
+    if (!user) return;
+    setExporting(true);
+    try {
+      let accessToken: string | undefined = session?.access_token;
+      if (!accessToken) {
+        const { data } = await supabase.auth.getSession();
+        accessToken = data.session?.access_token;
+      }
+      if (!accessToken) {
+        toast({
+          title: "Not Authenticated",
+          description: "Could not find your session. Please login again.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const res = await fetch("https://wjxxgccfazpkdfzbcgen.functions.supabase.co/export-user-data", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "Failed to export data" }));
+        throw new Error(err.error || "Failed to export data");
+      }
+
+      const data = await res.json();
+      generateUserDataPDF(data);
+
+      toast({
+        title: "Download started",
+        description: "Your data export PDF is being downloaded.",
+      });
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to export your data.",
+        variant: "destructive",
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const handleDeleteAccount = async () => {
     if (!user) return;
     setDeleting(true);
@@ -280,13 +391,13 @@ const Account = () => {
       <main className="max-w-4xl mx-auto px-3 sm:px-4 lg:px-8 py-4 lg:py-8">
         {/* Page Header */}
         <div className="mb-6 lg:mb-8">
-          <Button 
-            variant="ghost" 
-            onClick={() => navigate('/dashboard')}
+          <Button
+            variant="ghost"
+            onClick={goBack}
             className="mb-4 flex items-center space-x-2 text-gray-600 hover:text-gray-900 text-sm sm:text-base"
           >
             <ArrowLeft className="h-3 w-3 sm:h-4 sm:w-4" />
-            <span>Back to Dashboard</span>
+            <span>Back</span>
           </Button>
           
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
@@ -297,7 +408,7 @@ const Account = () => {
           </p>
         </div>
 
-        <Tabs defaultValue="profile" className="space-y-6">
+        <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="profile" className="flex items-center space-x-2">
               <User className="h-4 w-4" />
@@ -307,9 +418,9 @@ const Account = () => {
               <Crown className="h-4 w-4" />
               <span>Subscription</span>
             </TabsTrigger>
-            <TabsTrigger value="security" className="flex items-center space-x-2 text-red-700">
-              <Trash2 className="h-4 w-4" />
-              <span>Security</span>
+            <TabsTrigger value="security" className="flex items-center space-x-2">
+              <Shield className="h-4 w-4" />
+              <span>Security & Privacy</span>
             </TabsTrigger>
           </TabsList>
 
@@ -391,18 +502,91 @@ const Account = () => {
             </Card>
           </TabsContent>
 
-          {/* Security Tab */}
+          {/* Security & Privacy Tab */}
           <TabsContent value="security" className="space-y-6">
+            {/* Change Password */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <KeyRound className="h-5 w-5 text-blue-600" />
+                  <span>Change Password</span>
+                </CardTitle>
+                <CardDescription>
+                  Choose a new password with at least 8 characters. You'll stay signed in on this device.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="new_password">New Password</Label>
+                    <Input
+                      id="new_password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      placeholder="At least 8 characters"
+                      disabled={changingPassword}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="confirm_password">Confirm New Password</Label>
+                    <Input
+                      id="confirm_password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="Re-enter your new password"
+                      disabled={changingPassword}
+                    />
+                  </div>
+                </div>
+                <Button
+                  onClick={handleChangePassword}
+                  disabled={changingPassword || !newPassword || !confirmPassword}
+                  className="flex items-center space-x-2"
+                >
+                  {changingPassword ? <Loader2 className="h-4 w-4 animate-spin" /> : <KeyRound className="h-4 w-4" />}
+                  <span>{changingPassword ? 'Updating...' : 'Update Password'}</span>
+                </Button>
+              </CardContent>
+            </Card>
+
+            {/* Download My Data */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Download className="h-5 w-5 text-emerald-600" />
+                  <span>Download My Data</span>
+                </CardTitle>
+                <CardDescription>
+                  Get a friendly PDF summary of everything we store about you — baby profiles, activities, memories, subscriptions, and account history.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  onClick={handleExportData}
+                  disabled={exporting}
+                  variant="outline"
+                  className="flex items-center space-x-2"
+                >
+                  {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                  <span>{exporting ? 'Preparing download...' : 'Download my data (PDF)'}</span>
+                </Button>
+              </CardContent>
+            </Card>
+
             {isViewerOnly && (
               <Alert className="border-amber-200 bg-amber-50">
                 <Info className="h-4 w-4 text-amber-600" />
                 <AlertDescription className="text-amber-800">
-                  You are currently a viewer in a family sharing setup. Account deletion is not available to viewers. 
+                  You are currently a viewer in a family sharing setup. Account deletion is not available to viewers.
                   If you want to leave the family, contact the baby's owner to remove you from family sharing.
                 </AlertDescription>
               </Alert>
             )}
-            
+
             {!isViewerOnly && (
               <Card>
                 <CardHeader>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -8,10 +8,11 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { LanguageSelector } from "@/components/LanguageSelector";
-import { ArrowLeft, Mail, MessageCircle, Clock, Send, HelpCircle, Users, Briefcase, CheckCircle, User, LogOut } from "lucide-react";
+import { ArrowLeft, Mail, MessageCircle, Clock, Send, HelpCircle, Users, Briefcase, CheckCircle, User, Sparkles } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { DesktopHeader } from '@/components/layout/DesktopHeader';
 import { MobileHeader } from '@/components/layout/MobileHeader';
 import { fbqTrack } from '@/utils/metaPixel';
@@ -21,6 +22,7 @@ const Contact = () => {
   const { t } = useTranslation();
   const { toast } = useToast();
   const { user, signOut } = useAuth();
+  const goBack = useSmartBack(user ? '/dashboard' : '/');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [formData, setFormData] = useState({
@@ -117,7 +119,14 @@ const Contact = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50/40 to-indigo-50">
+      {/* Decorative blurred blobs */}
+      <div className="pointer-events-none fixed inset-0 overflow-hidden -z-10">
+        <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-pink-300/20 blur-3xl" />
+        <div className="absolute top-1/3 -right-32 w-[28rem] h-[28rem] rounded-full bg-purple-300/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/3 w-80 h-80 rounded-full bg-indigo-300/20 blur-3xl" />
+      </div>
+
       {/* Conditional Navigation */}
       {user ? (
         <>
@@ -125,18 +134,18 @@ const Contact = () => {
           <MobileHeader />
         </>
       ) : (
-        <nav className="bg-white/80 backdrop-blur-sm border-b border-blue-100 sticky top-0 z-50">
+        <nav className="bg-white/70 backdrop-blur-md border-b border-white/60 sticky top-0 z-50">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between items-center h-16">
               <div className="flex items-center space-x-2 sm:space-x-4">
-                <Button variant="ghost" size="sm" onClick={() => navigate('/')} className="flex items-center space-x-1 sm:space-x-2 p-2 sm:px-3">
+                <Button variant="ghost" size="sm" onClick={goBack} className="flex items-center space-x-1 sm:space-x-2 p-2 sm:px-3">
                   <ArrowLeft className="h-4 w-4" />
                   <span className="hidden sm:inline">Back</span>
                 </Button>
                 <div className="flex items-center space-x-2">
-                  <img 
-                    src="/lovable-uploads/5e403470-892e-4e72-8a4e-faa117177a49.png" 
-                    alt="SleepyBabyy Logo" 
+                  <img
+                    src="/lovable-uploads/5e403470-892e-4e72-8a4e-faa117177a49.png"
+                    alt="SleepyBabyy Logo"
                     className="h-8 w-8 sm:h-10 sm:w-10"
                   />
                   <span className="text-lg sm:text-xl font-semibold text-gray-900">{t('app.name')}</span>
@@ -161,15 +170,36 @@ const Contact = () => {
         </nav>
       )}
 
+      {/* Back button for logged-in users (matches Memories / Reports / FamilySharing) */}
+      {user && (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={goBack}
+            className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 hover:bg-white/60 touch-target"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Back</span>
+          </Button>
+        </div>
+      )}
+
       {/* Hero Section */}
-      <section className="py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8">
+      <section className="py-10 sm:py-14 lg:py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto text-center">
-          <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-4 sm:mb-6">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/70 backdrop-blur-sm border border-pink-200/60 text-pink-700 text-xs sm:text-sm font-medium mb-5 shadow-sm">
+            <Sparkles className="h-3.5 w-3.5" />
+            <span>We reply within 24 hours</span>
+          </div>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 mb-4 sm:mb-6 leading-tight">
             Get in Touch
-            <span className="text-blue-600 block">We're Here to Help</span>
+            <span className="block mt-2 bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 bg-clip-text text-transparent">
+              We're Here to Help
+            </span>
           </h1>
-          <p className="text-base sm:text-lg lg:text-xl text-gray-600 mb-6 sm:mb-8 leading-relaxed px-2 sm:px-0">
-            Have questions about SleepyBabyy? Need support with your account? 
+          <p className="text-base sm:text-lg lg:text-xl text-gray-600 mb-2 leading-relaxed px-2 sm:px-0 max-w-2xl mx-auto">
+            Have questions about SleepyBabyy? Need support with your account?
             Want to share feedback? We'd love to hear from you.
           </p>
         </div>
@@ -181,7 +211,8 @@ const Contact = () => {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 sm:gap-12">
             {/* Contact Form */}
             <div className="lg:col-span-2 order-2 lg:order-1">
-              <Card className="border-0 shadow-xl">
+              <Card className="border border-white/60 shadow-xl shadow-purple-500/5 bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden">
+                <div className="h-1.5 bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500" />
                 <CardHeader className="p-4 sm:p-6">
                   <CardTitle className="text-xl sm:text-2xl">
                     {isSubmitted ? (
@@ -280,10 +311,10 @@ const Contact = () => {
                         />
                       </div>
 
-                      <Button 
-                        type="submit" 
-                        size="lg" 
-                        className="w-full bg-blue-600 hover:bg-blue-700 touch-target"
+                      <Button
+                        type="submit"
+                        size="lg"
+                        className="w-full bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0 shadow-lg shadow-purple-500/30 hover:shadow-xl hover:shadow-purple-500/40 transition-all duration-300 hover:scale-[1.02] touch-target"
                         disabled={isSubmitting}
                       >
                         {isSubmitting ? (
@@ -327,31 +358,37 @@ const Contact = () => {
             {/* Contact Information */}
             <div className="space-y-6 sm:space-y-8 order-1 lg:order-2">
               {/* Contact Methods */}
-              <Card className="border-0 shadow-lg">
-                <CardHeader className="p-4 sm:p-6">
-                  <CardTitle className="text-lg sm:text-xl">Contact Information</CardTitle>
+              <Card className="border border-white/60 shadow-lg shadow-pink-500/5 bg-white/80 backdrop-blur-sm rounded-2xl">
+                <CardHeader className="p-4 sm:p-6 pb-3">
+                  <CardTitle className="text-lg sm:text-xl bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent">Contact Information</CardTitle>
                 </CardHeader>
-                <CardContent className="p-4 sm:p-6 pt-0 space-y-4 sm:space-y-6">
-                  <div className="flex items-center space-x-3">
-                    <Mail className="h-5 w-5 text-blue-600 flex-shrink-0" />
-                    <div>
-                      <div className="font-medium text-sm sm:text-base">Email</div>
+                <CardContent className="p-4 sm:p-6 pt-0 space-y-4">
+                  <div className="flex items-center gap-3 p-3 rounded-xl bg-gradient-to-r from-pink-50 to-pink-50/40 hover:from-pink-100/80 hover:to-pink-100/40 transition-colors">
+                    <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-pink-400 to-pink-500 flex items-center justify-center shadow-sm shadow-pink-500/30 flex-shrink-0">
+                      <Mail className="h-5 w-5 text-white" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="font-semibold text-sm sm:text-base text-gray-900">Email</div>
                       <div className="text-xs sm:text-sm text-gray-600 break-all">support@sleepybabyy.com</div>
                     </div>
                   </div>
-                  
-                  <div className="flex items-center space-x-3">
-                    <MessageCircle className="h-5 w-5 text-green-600 flex-shrink-0" />
-                    <div>
-                      <div className="font-medium text-sm sm:text-base">Live Chat</div>
+
+                  <div className="flex items-center gap-3 p-3 rounded-xl bg-gradient-to-r from-purple-50 to-purple-50/40 hover:from-purple-100/80 hover:to-purple-100/40 transition-colors">
+                    <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-purple-400 to-purple-500 flex items-center justify-center shadow-sm shadow-purple-500/30 flex-shrink-0">
+                      <MessageCircle className="h-5 w-5 text-white" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="font-semibold text-sm sm:text-base text-gray-900">Live Chat</div>
                       <div className="text-xs sm:text-sm text-gray-600">Available in the app</div>
                     </div>
                   </div>
 
-                  <div className="flex items-center space-x-3">
-                    <Clock className="h-5 w-5 text-purple-600 flex-shrink-0" />
-                    <div>
-                      <div className="font-medium text-sm sm:text-base">Response Time</div>
+                  <div className="flex items-center gap-3 p-3 rounded-xl bg-gradient-to-r from-indigo-50 to-indigo-50/40 hover:from-indigo-100/80 hover:to-indigo-100/40 transition-colors">
+                    <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-indigo-400 to-indigo-500 flex items-center justify-center shadow-sm shadow-indigo-500/30 flex-shrink-0">
+                      <Clock className="h-5 w-5 text-white" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="font-semibold text-sm sm:text-base text-gray-900">Response Time</div>
                       <div className="text-xs sm:text-sm text-gray-600">Within 24 hours</div>
                     </div>
                   </div>
@@ -359,35 +396,47 @@ const Contact = () => {
               </Card>
 
               {/* Quick Links */}
-              <Card className="border-0 shadow-lg">
-                <CardHeader className="p-4 sm:p-6">
-                  <CardTitle className="text-lg sm:text-xl">Quick Help</CardTitle>
+              <Card className="border border-white/60 shadow-lg shadow-purple-500/5 bg-white/80 backdrop-blur-sm rounded-2xl">
+                <CardHeader className="p-4 sm:p-6 pb-3">
+                  <CardTitle className="text-lg sm:text-xl bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">Quick Help</CardTitle>
                 </CardHeader>
-                <CardContent className="p-4 sm:p-6 pt-0 space-y-3 sm:space-y-4">
-                  <Button variant="outline" className="w-full justify-start touch-target text-sm" onClick={() => navigate('/help')}>
-                    <HelpCircle className="h-4 w-4 mr-2 flex-shrink-0" />
+                <CardContent className="p-4 sm:p-6 pt-0 space-y-2.5">
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start touch-target text-sm rounded-xl border-pink-200 hover:bg-pink-50 hover:border-pink-300 hover:text-pink-700 transition-all"
+                    onClick={() => navigate('/help')}
+                  >
+                    <HelpCircle className="h-4 w-4 mr-2 flex-shrink-0 text-pink-500" />
                     Help Center & FAQ
                   </Button>
-                  
-                  <Button variant="outline" className="w-full justify-start touch-target text-sm" onClick={() => navigate('/family')}>
-                    <Users className="h-4 w-4 mr-2 flex-shrink-0" />
+
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start touch-target text-sm rounded-xl border-purple-200 hover:bg-purple-50 hover:border-purple-300 hover:text-purple-700 transition-all"
+                    onClick={() => navigate('/family')}
+                  >
+                    <Users className="h-4 w-4 mr-2 flex-shrink-0 text-purple-500" />
                     Family Sharing Help
                   </Button>
-                  
-                  <Button variant="outline" className="w-full justify-start touch-target text-sm" onClick={() => navigate('/subscription')}>
-                    <Briefcase className="h-4 w-4 mr-2 flex-shrink-0" />
+
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start touch-target text-sm rounded-xl border-indigo-200 hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-700 transition-all"
+                    onClick={() => navigate('/subscription')}
+                  >
+                    <Briefcase className="h-4 w-4 mr-2 flex-shrink-0 text-indigo-500" />
                     Subscription Support
                   </Button>
                 </CardContent>
               </Card>
 
               {/* Office Hours */}
-              <Card className="border-0 shadow-lg">
-                <CardHeader className="p-4 sm:p-6">
-                  <CardTitle className="text-lg sm:text-xl">Support Hours</CardTitle>
+              <Card className="border border-white/60 shadow-lg shadow-indigo-500/5 bg-white/80 backdrop-blur-sm rounded-2xl">
+                <CardHeader className="p-4 sm:p-6 pb-3">
+                  <CardTitle className="text-lg sm:text-xl bg-gradient-to-r from-indigo-600 to-pink-600 bg-clip-text text-transparent">Support Hours</CardTitle>
                 </CardHeader>
                 <CardContent className="p-4 sm:p-6 pt-0">
-                  <div className="space-y-2 text-xs sm:text-sm">
+                  <div className="space-y-2 text-xs sm:text-sm text-gray-700">
                     <div className="flex justify-between items-center">
                       <span>Monday - Friday</span>
                       <span className="font-medium text-right">9:00 AM - 6:00 PM EST</span>
@@ -398,15 +447,15 @@ const Contact = () => {
                     </div>
                     <div className="flex justify-between items-center">
                       <span>Sunday</span>
-                      <span className="font-medium text-right">Closed</span>
+                      <span className="font-medium text-right text-gray-500">Closed</span>
                     </div>
                   </div>
-                  <div className="mt-4 p-3 bg-blue-50 rounded-lg">
-                    <p className="text-xs sm:text-sm text-blue-800">
-                      Emergency support available 24/7 for Premium subscribers
+                  <div className="mt-4 p-3 rounded-xl bg-gradient-to-r from-pink-50 via-purple-50 to-indigo-50 border border-purple-100">
+                    <p className="text-xs sm:text-sm text-purple-900 font-medium">
+                      ✨ Emergency support 24/7 for Premium subscribers
                     </p>
                     <div className="mt-2 flex items-center space-x-2">
-                      <span className="text-sm font-bold text-blue-800">Premium starts at $7.99/month</span>
+                      <span className="text-sm font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent">Premium starts at $7.99/month</span>
                     </div>
                   </div>
                 </CardContent>
@@ -417,37 +466,44 @@ const Contact = () => {
       </section>
 
       {/* FAQ Preview */}
-      <section className="py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8 bg-white">
+      <section className="py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8 bg-white/60 backdrop-blur-sm border-t border-white/60">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-8 sm:mb-12">
-            <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">
-              Frequently Asked Questions
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">
+              <span className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 bg-clip-text text-transparent">
+                Frequently Asked Questions
+              </span>
             </h2>
             <p className="text-sm sm:text-base text-gray-600 px-2 sm:px-0">
               Quick answers to common questions
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5 sm:gap-6">
             {[
               {
                 question: "How do I add family members?",
-                answer: "Go to Family Sharing in your dashboard and send invitations via email. Family members can join with the invitation link."
+                answer: "Go to Family Sharing in your dashboard and send invitations via email. Family members can join with the invitation link.",
+                accent: "from-pink-400 to-pink-500"
               },
               {
                 question: "Can I export my data?",
-                answer: "Yes! Premium users can export all their data in CSV format from the Reports section."
+                answer: "Yes! Premium users can export all their data in CSV format from the Reports section.",
+                accent: "from-purple-400 to-purple-500"
               },
               {
                 question: "Is my baby's data secure?",
-                answer: "Absolutely. We use enterprise-grade encryption and never share personal data with third parties."
+                answer: "Absolutely. We use enterprise-grade encryption and never share personal data with third parties.",
+                accent: "from-indigo-400 to-indigo-500"
               },
               {
                 question: "How do I cancel my subscription?",
-                answer: "You can cancel anytime from your Account settings. Your data remains accessible until the end of your billing period."
+                answer: "You can cancel anytime from your Account settings. Your data remains accessible until the end of your billing period.",
+                accent: "from-pink-400 to-purple-500"
               }
             ].map((faq, index) => (
-              <Card key={index} className="border-0 shadow-sm">
+              <Card key={index} className="border border-white/60 shadow-md hover:shadow-lg bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden transition-all hover:-translate-y-0.5">
+                <div className={`h-1 bg-gradient-to-r ${faq.accent}`} />
                 <CardContent className="p-4 sm:p-6">
                   <h3 className="font-semibold text-gray-900 mb-2 text-sm sm:text-base">{faq.question}</h3>
                   <p className="text-gray-600 text-xs sm:text-sm leading-relaxed">{faq.answer}</p>
@@ -456,8 +512,12 @@ const Contact = () => {
             ))}
           </div>
 
-          <div className="text-center mt-6 sm:mt-8">
-            <Button onClick={() => navigate('/help')} variant="outline" size="lg" className="touch-target">
+          <div className="text-center mt-8 sm:mt-10">
+            <Button
+              onClick={() => navigate('/help')}
+              size="lg"
+              className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0 shadow-lg shadow-purple-500/30 hover:shadow-xl hover:shadow-purple-500/40 transition-all duration-300 hover:scale-[1.02] touch-target rounded-full px-8"
+            >
               View All FAQs
             </Button>
           </div>

--- a/src/pages/FamilySharing.tsx
+++ b/src/pages/FamilySharing.tsx
@@ -11,6 +11,7 @@ import {
   Users
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { FamilySharing as FamilySharingComponent } from '@/components/family/FamilySharing';
 import { BabyProfileSetup } from '@/components/tracking/BabyProfileSetup';
@@ -40,9 +41,7 @@ const FamilySharing = () => {
     navigate('/');
   };
 
-  const handleBack = () => {
-    navigate('/dashboard');
-  };
+  const handleBack = useSmartBack();
 
   if (loading || profileLoading) {
     return (

--- a/src/pages/Features.tsx
+++ b/src/pages/Features.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
+import { useSmartBack } from "@/hooks/useSmartBack";
 import { useTranslation } from "react-i18next";
 import { DesktopHeader } from "@/components/layout/DesktopHeader";
 import { MobileHeader } from "@/components/layout/MobileHeader";
@@ -13,6 +14,7 @@ import { Clock, Calendar, Volume2, Users, BarChart3, Globe, Baby, Heart, CheckCi
 const Features = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const goBack = useSmartBack(user ? '/dashboard' : '/');
   const { t } = useTranslation();
 
   // Scroll to top when component mounts
@@ -103,7 +105,7 @@ const Features = () => {
           
           {/* Back Button for Mobile (authenticated users) */}
           <div className="lg:hidden bg-white/80 backdrop-blur-sm border-b border-blue-100 px-4 py-3">
-            <Button variant="ghost" size="sm" onClick={() => navigate('/dashboard')} className="flex items-center space-x-2">
+            <Button variant="ghost" size="sm" onClick={goBack} className="flex items-center space-x-2">
               <ArrowLeft className="h-4 w-4" />
               <span>Back to Dashboard</span>
             </Button>

--- a/src/pages/HelpCenter.tsx
+++ b/src/pages/HelpCenter.tsx
@@ -6,10 +6,11 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
+import { useSmartBack } from "@/hooks/useSmartBack";
 import { DesktopHeader } from "@/components/layout/DesktopHeader";
 import { MobileHeader } from "@/components/layout/MobileHeader";
 import { LanguageSelector } from "@/components/LanguageSelector";
-import { ArrowLeft, Search, Book, MessageCircle, Download, Users, Settings, CreditCard, Baby, BarChart3, Volume2, Calendar, PlayCircle, GraduationCap, ArrowRight } from "lucide-react";
+import { ArrowLeft, Search, Book, MessageCircle, Download, Users, Settings, CreditCard, Baby, BarChart3, Volume2, Calendar, PlayCircle, GraduationCap, ArrowRight, Sparkles, X, SearchX } from "lucide-react";
 const HelpCenter = () => {
   const navigate = useNavigate();
   const {
@@ -18,6 +19,7 @@ const HelpCenter = () => {
   const {
     user
   } = useAuth();
+  const goBack = useSmartBack(user ? '/dashboard' : '/');
   const [searchQuery, setSearchQuery] = useState('');
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -37,42 +39,48 @@ const HelpCenter = () => {
     title: "Getting Started",
     description: "Learn the basics of SleepyBaby",
     articles: 12,
-    color: "text-blue-600",
+    gradient: "from-pink-400 to-pink-500",
+    accent: "bg-pink-50 text-pink-600",
     route: "/help/getting-started"
   }, {
     icon: Users,
     title: "Family Sharing",
     description: "Add family members and caregivers",
     articles: 8,
-    color: "text-green-600",
+    gradient: "from-purple-400 to-purple-500",
+    accent: "bg-purple-50 text-purple-600",
     route: "/help/family-sharing"
   }, {
     icon: BarChart3,
     title: "Reports & Analytics",
     description: "Understanding your baby's patterns",
     articles: 10,
-    color: "text-purple-600",
+    gradient: "from-indigo-400 to-indigo-500",
+    accent: "bg-indigo-50 text-indigo-600",
     route: "/help/reports-analytics"
   }, {
     icon: CreditCard,
     title: "Billing & Subscriptions",
     description: "Manage your premium subscription",
     articles: 6,
-    color: "text-orange-600",
+    gradient: "from-orange-400 to-pink-500",
+    accent: "bg-orange-50 text-orange-600",
     route: "/help/billing-subscriptions"
   }, {
     icon: Volume2,
     title: "Sounds & Sleep",
     description: "Using our sound library effectively",
     articles: 5,
-    color: "text-pink-600",
+    gradient: "from-pink-400 to-purple-500",
+    accent: "bg-pink-50 text-pink-600",
     route: "/help/sounds-sleep"
   }, {
     icon: Settings,
     title: "Account Settings",
     description: "Customize your app experience",
     articles: 7,
-    color: "text-indigo-600",
+    gradient: "from-purple-400 to-indigo-500",
+    accent: "bg-indigo-50 text-indigo-600",
     route: "/help/account-settings"
   }];
   const quickStartOptions = [{
@@ -80,30 +88,72 @@ const HelpCenter = () => {
     description: "Step-by-step guided tour of all features",
     icon: GraduationCap,
     action: () => navigate('/tutorial'),
-    color: "text-blue-600",
-    bgColor: "bg-blue-50"
+    gradient: "from-pink-400 to-purple-500"
   }, {
     title: "Quick Setup",
     description: "Get started in under 5 minutes",
     icon: Baby,
     action: () => navigate('/dashboard'),
-    color: "text-purple-600",
-    bgColor: "bg-purple-50"
+    gradient: "from-purple-400 to-indigo-500"
   }];
-  const popularArticles = ["How to create your first baby profile", "Understanding sleep pattern charts", "Inviting family members to collaborate", "Setting up smart notifications", "Exporting your baby's data", "Troubleshooting sync issues"];
+  const popularArticles = [
+    { title: "How to create your first baby profile", category: "getting-started" },
+    { title: "Understanding sleep pattern charts", category: "reports-analytics" },
+    { title: "Inviting family members to collaborate", category: "family-sharing" },
+    { title: "Setting up smart notifications", category: "account-settings" },
+    { title: "Exporting your baby's data", category: "reports-analytics" },
+    { title: "Troubleshooting sync issues", category: "account-settings" },
+  ];
   const handleCategoryClick = (route: string) => {
     // Extract category name from route and navigate to dynamic help articles page
     const categoryName = route.split('/').pop(); // Extract the last part of the route
     navigate(`/help/category/${categoryName}`);
   };
-  return <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+
+  // Live search: filter categories and articles by query
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isSearching = normalizedQuery.length > 0;
+  const filteredCategories = isSearching
+    ? categories.filter(c =>
+        c.title.toLowerCase().includes(normalizedQuery) ||
+        c.description.toLowerCase().includes(normalizedQuery)
+      )
+    : categories;
+  const filteredArticles = isSearching
+    ? popularArticles.filter(a => a.title.toLowerCase().includes(normalizedQuery))
+    : popularArticles;
+  const hasResults = filteredCategories.length > 0 || filteredArticles.length > 0;
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // If exactly one category matches, jump straight to it
+    if (isSearching && filteredCategories.length === 1) {
+      handleCategoryClick(filteredCategories[0].route);
+      return;
+    }
+    // If no categories matched but a single article did, open its category
+    if (isSearching && filteredCategories.length === 0 && filteredArticles.length === 1) {
+      navigate(`/help/category/${filteredArticles[0].category}`);
+      return;
+    }
+    // Otherwise let live results stay visible — just dismiss the mobile keyboard
+    (document.activeElement as HTMLElement | null)?.blur();
+  };
+  return <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50/40 to-indigo-50">
+      {/* Decorative blurred blobs */}
+      <div className="pointer-events-none fixed inset-0 overflow-hidden -z-10">
+        <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-pink-300/20 blur-3xl" />
+        <div className="absolute top-1/3 -right-32 w-[28rem] h-[28rem] rounded-full bg-purple-300/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/3 w-80 h-80 rounded-full bg-indigo-300/20 blur-3xl" />
+      </div>
+
       {/* Conditional Headers */}
       {user ? <>
           <DesktopHeader />
           <MobileHeader />
         </> : <>
           {/* Non-authenticated Desktop Header */}
-          <header className="bg-white/80 backdrop-blur-sm border-b border-blue-100 hidden lg:block">
+          <header className="bg-white/70 backdrop-blur-md border-b border-white/60 hidden lg:block">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
               <div className="flex justify-between items-center h-16">
                 <div className="flex items-center space-x-2">
@@ -124,7 +174,7 @@ const HelpCenter = () => {
                   <Button variant="outline" onClick={handleSignIn}>
                     Sign In
                   </Button>
-                  <Button onClick={handleGetStarted}>
+                  <Button onClick={handleGetStarted} className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0 shadow-md shadow-purple-500/30">
                     Get Started
                   </Button>
                 </div>
@@ -133,7 +183,7 @@ const HelpCenter = () => {
           </header>
 
           {/* Non-authenticated Mobile Header */}
-          <header className="bg-white/80 backdrop-blur-sm border-b border-blue-100 lg:hidden">
+          <header className="bg-white/70 backdrop-blur-md border-b border-white/60 lg:hidden">
             <div className="flex justify-between items-center h-16 px-4">
               <div className="flex items-center space-x-2">
                 <img src="/lovable-uploads/5e403470-892e-4e72-8a4e-faa117177a49.png" alt="SleepyBabyy Logo" className="h-10 w-auto" />
@@ -141,7 +191,7 @@ const HelpCenter = () => {
               </div>
               <div className="flex items-center space-x-2">
                 <LanguageSelector />
-                <Button size="sm" onClick={handleGetStarted}>
+                <Button size="sm" onClick={handleGetStarted} className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0">
                   Get Started
                 </Button>
               </div>
@@ -150,57 +200,102 @@ const HelpCenter = () => {
         </>}
 
       {/* Hero Section with integrated navigation */}
-      <section className="py-12 md:py-16 px-4 sm:px-6 lg:px-8">
+      <section className="py-10 md:py-14 px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
           {/* Back button and tutorial button */}
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 gap-4">
-            <Button variant="ghost" size="sm" onClick={() => navigate(user ? '/dashboard' : '/')} className="flex items-center space-x-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={goBack}
+              className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 hover:bg-white/60 touch-target"
+            >
               <ArrowLeft className="h-4 w-4" />
-              <span>{user ? 'Back to Dashboard' : 'Back to Home'}</span>
+              <span>Back</span>
             </Button>
-            <Button onClick={() => navigate('/tutorial')} className="bg-blue-600 hover:bg-blue-700">
+            <Button
+              onClick={() => navigate('/tutorial')}
+              className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0 shadow-lg shadow-purple-500/30 hover:shadow-xl hover:shadow-purple-500/40 transition-all duration-300 hover:scale-[1.02] rounded-full px-6"
+            >
+              <Sparkles className="h-4 w-4 mr-2" />
               Start Tutorial
             </Button>
           </div>
 
           {/* Hero content */}
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4 md:mb-6">
+            <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/70 backdrop-blur-sm border border-pink-200/60 text-pink-700 text-xs sm:text-sm font-medium mb-5 shadow-sm">
+              <Sparkles className="h-3.5 w-3.5" />
+              <span>Answers, guides, and more</span>
+            </div>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-4 md:mb-6 leading-tight">
               Help Center
-              <span className="text-blue-600 block">How can we help you?</span>
+              <span className="block mt-2 bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 bg-clip-text text-transparent">
+                How can we help you?
+              </span>
             </h1>
-            <p className="text-lg md:text-xl text-gray-600 mb-6 md:mb-8 leading-relaxed">
-              Find answers to common questions, learn how to use SleepyBaby effectively, 
+            <p className="text-base md:text-lg lg:text-xl text-gray-600 mb-6 md:mb-8 leading-relaxed max-w-2xl mx-auto">
+              Find answers to common questions, learn how to use SleepyBaby effectively,
               and get the most out of your baby tracking experience.
             </p>
-            
+
             {/* Search Bar */}
-            <div className="relative max-w-2xl mx-auto">
-              <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-              <Input type="text" placeholder="Search for help articles..." className="pl-12 pr-4 py-4 md:py-6 text-base md:text-lg border-2 border-blue-200 focus:border-blue-500" value={searchQuery} onChange={e => setSearchQuery(e.target.value)} />
-            </div>
+            <form onSubmit={handleSearchSubmit} className="relative max-w-2xl mx-auto" role="search">
+              <Search className="pointer-events-none absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 h-4 w-4 sm:h-5 sm:w-5 text-purple-400" />
+              <Input
+                type="text"
+                inputMode="search"
+                enterKeyHint="search"
+                aria-label="Search help articles"
+                placeholder="Search for help articles..."
+                className="pl-10 sm:pl-12 pr-12 sm:pr-14 py-3 sm:py-4 md:py-6 text-sm sm:text-base md:text-lg border-2 border-purple-200/70 bg-white/80 backdrop-blur-sm focus:border-purple-400 focus-visible:ring-2 focus-visible:ring-purple-200 rounded-2xl shadow-sm [&::-webkit-search-cancel-button]:appearance-none"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+              />
+              {isSearching && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery('')}
+                  aria-label="Clear search"
+                  className="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 h-8 w-8 sm:h-9 sm:w-9 rounded-full bg-purple-100/70 hover:bg-purple-200/70 flex items-center justify-center transition-colors touch-target"
+                >
+                  <X className="h-4 w-4 text-purple-700" />
+                </button>
+              )}
+              <button type="submit" className="sr-only" aria-label="Submit search">Search</button>
+            </form>
+            {isSearching && (
+              <p className="mt-3 text-xs sm:text-sm text-gray-600">
+                {hasResults
+                  ? `${filteredCategories.length + filteredArticles.length} result${filteredCategories.length + filteredArticles.length === 1 ? '' : 's'} for "${searchQuery.trim()}"`
+                  : `No matches for "${searchQuery.trim()}"`}
+              </p>
+            )}
           </div>
         </div>
       </section>
 
-      {/* Quick Start Section */}
-      <section className="py-8 md:py-12 px-4 sm:px-6 lg:px-8 bg-white">
+      {/* Quick Start Section — hidden while searching */}
+      <section className={`py-8 md:py-12 px-4 sm:px-6 lg:px-8 bg-white/60 backdrop-blur-sm border-y border-white/60 ${isSearching ? 'hidden' : ''}`}>
         <div className="max-w-7xl mx-auto">
-          <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-8 md:mb-12">
-            Quick Start Options
+          <h2 className="text-2xl md:text-3xl font-bold text-center mb-8 md:mb-12">
+            <span className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 bg-clip-text text-transparent">
+              Quick Start Options
+            </span>
           </h2>
-          
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mb-8 md:mb-12">
+
+          <div className="grid sm:grid-cols-2 gap-6 md:gap-8 mb-4 md:mb-8 max-w-3xl mx-auto">
             {quickStartOptions.map((option, index) => {
             const IconComponent = option.icon;
-            return <Card key={index} className="border-0 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer group" onClick={option.action}>
+            return <Card key={index} className="border border-white/60 shadow-lg hover:shadow-xl shadow-purple-500/5 bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden cursor-pointer group transition-all hover:-translate-y-1" onClick={option.action}>
+                  <div className={`h-1.5 bg-gradient-to-r ${option.gradient}`} />
                   <CardContent className="p-6 md:p-8 text-center">
-                    <div className={`inline-flex p-3 md:p-4 rounded-2xl ${option.bgColor} mb-4 md:mb-6 group-hover:scale-110 transition-transform`}>
-                      <IconComponent className={`h-6 w-6 md:h-8 md:w-8 ${option.color}`} />
+                    <div className={`inline-flex h-14 w-14 md:h-16 md:w-16 rounded-2xl bg-gradient-to-br ${option.gradient} mb-4 md:mb-5 items-center justify-center shadow-md shadow-purple-500/20 group-hover:scale-110 transition-transform`}>
+                      <IconComponent className="h-7 w-7 md:h-8 md:w-8 text-white" />
                     </div>
-                    <h3 className="text-lg md:text-xl font-bold text-gray-900 mb-2 md:mb-3">{option.title}</h3>
-                    <p className="text-sm md:text-base text-gray-600 mb-3 md:mb-4">{option.description}</p>
-                    <div className="flex items-center justify-center text-blue-600 group-hover:text-blue-700">
+                    <h3 className="text-lg md:text-xl font-bold text-gray-900 mb-2">{option.title}</h3>
+                    <p className="text-sm md:text-base text-gray-600 mb-4">{option.description}</p>
+                    <div className="inline-flex items-center text-purple-600 group-hover:text-purple-700 font-medium">
                       <span className="mr-2 text-sm md:text-base">Get Started</span>
                       <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
                     </div>
@@ -211,29 +306,58 @@ const HelpCenter = () => {
         </div>
       </section>
 
+      {/* No-results state */}
+      {isSearching && !hasResults && (
+        <section className="py-12 md:py-16 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-xl mx-auto text-center bg-white/80 backdrop-blur-sm border border-white/60 rounded-2xl shadow-md p-8 sm:p-10">
+            <div className="inline-flex h-14 w-14 sm:h-16 sm:w-16 rounded-2xl bg-gradient-to-br from-pink-100 to-purple-100 items-center justify-center mb-4">
+              <SearchX className="h-7 w-7 sm:h-8 sm:w-8 text-purple-500" />
+            </div>
+            <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-2">No matches found</h3>
+            <p className="text-sm sm:text-base text-gray-600 mb-6">
+              We couldn't find anything for "{searchQuery.trim()}". Try a different keyword or contact our support team.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Button variant="outline" onClick={() => setSearchQuery('')} className="rounded-full">
+                Clear search
+              </Button>
+              <Button
+                onClick={() => navigate('/contact')}
+                className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white border-0 shadow-md rounded-full"
+              >
+                Contact Support
+              </Button>
+            </div>
+          </div>
+        </section>
+      )}
+
       {/* Help Categories */}
-      <section className="py-8 md:py-12 px-4 sm:px-6 lg:px-8">
+      <section className={`py-10 md:py-14 px-4 sm:px-6 lg:px-8 ${filteredCategories.length === 0 ? 'hidden' : ''}`}>
         <div className="max-w-7xl mx-auto">
-          <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-900 mb-8 md:mb-12">
-            Browse by Category
+          <h2 className="text-2xl md:text-3xl font-bold text-center mb-8 md:mb-12">
+            <span className="bg-gradient-to-r from-purple-500 to-indigo-500 bg-clip-text text-transparent">
+              {isSearching ? 'Matching Categories' : 'Browse by Category'}
+            </span>
           </h2>
-          
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-            {categories.map((category, index) => {
+
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6">
+            {filteredCategories.map((category, index) => {
             const IconComponent = category.icon;
-            return <Card key={index} className="border-0 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer group" onClick={() => handleCategoryClick(category.route)}>
-                  <CardHeader className="pb-4">
-                    <div className={`inline-flex p-2 md:p-3 rounded-2xl bg-gray-50 mb-3 md:mb-4 w-fit group-hover:scale-110 transition-transform`}>
-                      <IconComponent className={`h-6 w-6 md:h-8 md:w-8 ${category.color}`} />
+            return <Card key={index} className="border border-white/60 shadow-md hover:shadow-xl shadow-purple-500/5 bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden cursor-pointer group transition-all hover:-translate-y-1" onClick={() => handleCategoryClick(category.route)}>
+                  <div className={`h-1.5 bg-gradient-to-r ${category.gradient}`} />
+                  <CardHeader className="pb-3">
+                    <div className={`inline-flex h-12 w-12 md:h-14 md:w-14 rounded-xl bg-gradient-to-br ${category.gradient} mb-3 items-center justify-center shadow-sm group-hover:scale-110 transition-transform`}>
+                      <IconComponent className="h-6 w-6 md:h-7 md:w-7 text-white" />
                     </div>
                     <CardTitle className="text-lg md:text-xl">{category.title}</CardTitle>
                     <CardDescription className="text-sm md:text-base">{category.description}</CardDescription>
                   </CardHeader>
                   <CardContent>
                     <div className="flex items-center justify-between">
-                      <Badge variant="secondary" className="text-xs md:text-sm">3 articles</Badge>
-                      <div className="flex items-center text-blue-600 group-hover:text-blue-700">
-                        <span className="mr-2 text-sm">Browse</span>
+                      <Badge className={`text-xs ${category.accent} border-0`}>{category.articles} articles</Badge>
+                      <div className="flex items-center text-purple-600 group-hover:text-purple-700 font-medium">
+                        <span className="mr-1 text-sm">Browse</span>
                         <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
                       </div>
                     </div>
@@ -244,21 +368,25 @@ const HelpCenter = () => {
         </div>
       </section>
 
-      {/* Popular Articles */}
-      <section className="py-12 md:py-16 px-4 sm:px-6 lg:px-8 bg-white">
+      {/* Popular Articles + Resources — Resources hidden during search */}
+      <section className={`py-12 md:py-16 px-4 sm:px-6 lg:px-8 bg-white/60 backdrop-blur-sm border-t border-white/60 ${filteredArticles.length === 0 && isSearching ? 'hidden' : ''}`}>
         <div className="max-w-6xl mx-auto">
-          <div className="grid lg:grid-cols-2 gap-8 md:gap-12">
-            <div>
-              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6 md:mb-8">
-                Popular Articles
+          <div className={`grid ${isSearching ? '' : 'lg:grid-cols-2'} gap-8 md:gap-12`}>
+            <div className={filteredArticles.length === 0 ? 'hidden' : ''}>
+              <h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
+                <span className="bg-gradient-to-r from-pink-500 to-purple-500 bg-clip-text text-transparent">
+                  {isSearching ? 'Matching Articles' : 'Popular Articles'}
+                </span>
               </h2>
-              <div className="space-y-3 md:space-y-4">
-                {popularArticles.map((article, index) => <Card key={index} className="border-0 shadow-sm hover:shadow-md transition-all duration-300 cursor-pointer">
+              <div className="space-y-3">
+                {filteredArticles.map((article, index) => <Card key={index} onClick={() => navigate(`/help/category/${article.category}`)} className="border border-white/60 shadow-sm hover:shadow-md hover:-translate-y-0.5 bg-white/80 backdrop-blur-sm rounded-xl transition-all duration-300 cursor-pointer group">
                     <CardContent className="p-3 md:p-4">
                       <div className="flex items-center space-x-3">
-                        <Book className="h-4 w-4 md:h-5 md:w-5 text-blue-600 flex-shrink-0" />
-                        <span className="text-sm md:text-base text-gray-900 hover:text-blue-600 transition-colors">
-                          {article}
+                        <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-pink-400 to-purple-500 flex items-center justify-center flex-shrink-0 shadow-sm">
+                          <Book className="h-4 w-4 text-white" />
+                        </div>
+                        <span className="text-sm md:text-base text-gray-900 group-hover:text-purple-700 transition-colors">
+                          {article.title}
                         </span>
                       </div>
                     </CardContent>
@@ -266,15 +394,20 @@ const HelpCenter = () => {
               </div>
             </div>
 
-            <div>
-              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6 md:mb-8">
-                Additional Resources
+            <div className={isSearching ? 'hidden' : ''}>
+              <h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8">
+                <span className="bg-gradient-to-r from-purple-500 to-indigo-500 bg-clip-text text-transparent">
+                  Additional Resources
+                </span>
               </h2>
-              <div className="space-y-4 md:space-y-6">
-                <Card className="border-0 shadow-lg cursor-pointer" onClick={() => navigate('/tutorial')}>
+              <div className="space-y-4">
+                <Card className="border border-white/60 shadow-md hover:shadow-lg bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden cursor-pointer transition-all hover:-translate-y-0.5" onClick={() => navigate('/tutorial')}>
+                  <div className="h-1 bg-gradient-to-r from-pink-400 to-purple-500" />
                   <CardContent className="p-4 md:p-6">
                     <div className="flex items-center space-x-3 md:space-x-4">
-                      <GraduationCap className="h-6 w-6 md:h-8 md:w-8 text-blue-600 flex-shrink-0" />
+                      <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-pink-400 to-purple-500 flex items-center justify-center flex-shrink-0 shadow-sm shadow-purple-500/20">
+                        <GraduationCap className="h-6 w-6 text-white" />
+                      </div>
                       <div>
                         <h3 className="font-bold text-base md:text-lg">Interactive Tutorial</h3>
                         <p className="text-sm md:text-base text-gray-600">Complete step-by-step walkthrough</p>
@@ -283,10 +416,13 @@ const HelpCenter = () => {
                   </CardContent>
                 </Card>
 
-                <Card className="border-0 shadow-lg">
+                <Card className="border border-white/60 shadow-md hover:shadow-lg bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden transition-all hover:-translate-y-0.5">
+                  <div className="h-1 bg-gradient-to-r from-purple-400 to-indigo-500" />
                   <CardContent className="p-4 md:p-6">
                     <div className="flex items-center space-x-3 md:space-x-4">
-                      <Download className="h-6 w-6 md:h-8 md:w-8 text-purple-600 flex-shrink-0" />
+                      <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-purple-400 to-indigo-500 flex items-center justify-center flex-shrink-0 shadow-sm shadow-purple-500/20">
+                        <Download className="h-6 w-6 text-white" />
+                      </div>
                       <div>
                         <h3 className="font-bold text-base md:text-lg">User Manual</h3>
                         <p className="text-sm md:text-base text-gray-600">Complete guide to SleepyBaby (PDF)</p>
@@ -295,10 +431,13 @@ const HelpCenter = () => {
                   </CardContent>
                 </Card>
 
-                <Card className="border-0 shadow-lg">
+                <Card className="border border-white/60 shadow-md hover:shadow-lg bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden transition-all hover:-translate-y-0.5">
+                  <div className="h-1 bg-gradient-to-r from-indigo-400 to-pink-500" />
                   <CardContent className="p-4 md:p-6">
                     <div className="flex items-center space-x-3 md:space-x-4">
-                      <MessageCircle className="h-6 w-6 md:h-8 md:w-8 text-orange-600 flex-shrink-0" />
+                      <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-indigo-400 to-pink-500 flex items-center justify-center flex-shrink-0 shadow-sm shadow-indigo-500/20">
+                        <MessageCircle className="h-6 w-6 text-white" />
+                      </div>
                       <div>
                         <h3 className="font-bold text-base md:text-lg">Community Forum</h3>
                         <p className="text-sm md:text-base text-gray-600">Connect with other parents</p>
@@ -308,16 +447,18 @@ const HelpCenter = () => {
                 </Card>
 
                 {/* Premium pricing info */}
-                <Card className="border-0 shadow-lg bg-orange-50 border-orange-200">
+                <Card className="border border-purple-200/60 shadow-md bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 backdrop-blur-sm rounded-2xl overflow-hidden">
                   <CardContent className="p-4 md:p-6">
                     <div className="flex items-start space-x-3 md:space-x-4">
-                      <CreditCard className="h-6 w-6 md:h-8 md:w-8 text-orange-600 flex-shrink-0 mt-1" />
+                      <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-pink-500 via-purple-500 to-indigo-500 flex items-center justify-center flex-shrink-0 shadow-sm shadow-purple-500/30">
+                        <CreditCard className="h-6 w-6 text-white" />
+                      </div>
                       <div className="flex-1">
                         <h3 className="font-bold text-base md:text-lg">Premium Support</h3>
                         <p className="text-sm md:text-base text-gray-600 mb-2">Priority support for Premium users</p>
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-lg font-bold text-orange-600">From $7.99/month</span>
-                          <Badge className="bg-orange-500 text-white text-xs">7-day free trial</Badge>
+                          <span className="text-lg font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent">From $7.99/month</span>
+                          <Badge className="bg-gradient-to-r from-pink-500 to-purple-500 text-white text-xs border-0">7-day free trial</Badge>
                         </div>
                       </div>
                     </div>
@@ -330,18 +471,25 @@ const HelpCenter = () => {
       </section>
 
       {/* Contact Support */}
-      <section className="py-12 md:py-16 px-4 sm:px-6 lg:px-8 bg-gradient-to-r from-blue-600 to-purple-600">
-        <div className="max-w-4xl mx-auto text-center">
+      <section className="py-12 md:py-16 px-4 sm:px-6 lg:px-8 bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_50%,rgba(255,255,255,0.1)_0%,transparent_50%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_50%,rgba(255,255,255,0.08)_0%,transparent_50%)]" />
+        <div className="max-w-4xl mx-auto text-center relative">
           <h2 className="text-2xl md:text-4xl font-bold text-white mb-4 md:mb-6">
             Still Need Help?
           </h2>
-          <p className="text-lg md:text-xl text-blue-100 mb-6 md:mb-8">Can't find what you're looking for? Our support team is here to help you get the most out of SleepyBabyy.</p>
+          <p className="text-lg md:text-xl text-white/90 mb-6 md:mb-8">Can't find what you're looking for? Our support team is here to help you get the most out of SleepyBabyy.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button size="lg" onClick={() => navigate('/contact')} className="bg-white text-blue-600 hover:bg-blue-50">
+            <Button
+              size="lg"
+              onClick={() => navigate('/contact')}
+              className="bg-white text-purple-600 hover:bg-white/95 hover:scale-[1.02] shadow-xl shadow-black/10 rounded-full px-8 font-semibold transition-all"
+            >
+              <MessageCircle className="h-5 w-5 mr-2" />
               Contact Support
             </Button>
           </div>
-          <p className="text-blue-100 text-sm mt-4 md:mt-6">
+          <p className="text-white/80 text-sm mt-4 md:mt-6">
             Average response time: Under 24 hours
           </p>
         </div>

--- a/src/pages/Memories.tsx
+++ b/src/pages/Memories.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { useBabyMemories } from '@/hooks/useBabyMemories';
 import { useSubscription } from '@/hooks/useSubscription';
@@ -16,6 +17,7 @@ import { UpgradePrompt } from '@/components/subscription/UpgradePrompt';
 
 const Memories = () => {
   const navigate = useNavigate();
+  const goBack = useSmartBack();
   const { user, loading: authLoading } = useAuth();
   const { activeProfile } = useBabyProfile();
   const { isPremium } = useSubscription();
@@ -55,13 +57,13 @@ const Memories = () => {
         
         <main className="max-w-7xl mx-auto px-4 py-8">
           <div className="mb-6">
-            <Button 
-              variant="ghost" 
-              onClick={() => navigate('/dashboard')}
+            <Button
+              variant="ghost"
+              onClick={goBack}
               className="mb-4 hover:bg-primary/10"
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Dashboard
+              Back
             </Button>
           </div>
 
@@ -93,13 +95,13 @@ const Memories = () => {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Header */}
         <div className="mb-6">
-          <Button 
-            variant="ghost" 
-            onClick={() => navigate('/dashboard')}
+          <Button
+            variant="ghost"
+            onClick={goBack}
             className="mb-4 hover:bg-primary/10"
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Dashboard
+            Back
           </Button>
           
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -5,12 +5,14 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft, Bell } from 'lucide-react';
 import { SmartNotifications } from '@/components/notifications/SmartNotifications';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useEffect } from 'react';
 import { useIsMobile } from '@/hooks/use-mobile';
 
 const Notifications = () => {
   const { user, loading } = useAuth();
   const navigate = useNavigate();
+  const goBack = useSmartBack();
   const { t } = useTranslation();
   const isMobile = useIsMobile();
 
@@ -38,11 +40,11 @@ const Notifications = () => {
       <div className="max-w-lg md:max-w-3xl lg:max-w-5xl mx-auto px-4 md:px-6 py-6 md:py-10">
         {/* Header */}
         <div className="flex items-center gap-3 mb-6">
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             size="icon"
             className="h-9 w-9 rounded-full"
-            onClick={() => navigate('/dashboard')}
+            onClick={goBack}
           >
             <ArrowLeft className="h-4 w-4" />
           </Button>

--- a/src/pages/PediatricianReports.tsx
+++ b/src/pages/PediatricianReports.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { FileText, Baby, ArrowLeft, Clock, TrendingUp, BarChart3 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { useSubscription } from '@/hooks/useSubscription';
 import { FeatureGate } from '@/components/subscription/FeatureGate';
@@ -39,7 +40,7 @@ const PediatricianReports = () => {
     }
   }, [user, loading, navigate]);
 
-  const handleBackToDashboard = () => navigate('/dashboard');
+  const handleBackToDashboard = useSmartBack();
 
   const rangeMap: Record<string, DateRangeOption> = {
     'comprehensive': 'last30Days',

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -11,6 +11,7 @@ import {
   BarChart3
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { ReportsOverview } from '@/components/reports/ReportsOverview';
 import { SleepAnalytics } from '@/components/reports/SleepAnalytics';
@@ -45,9 +46,7 @@ const Reports = () => {
     navigate('/');
   };
 
-  const handleBackToDashboard = () => {
-    navigate('/dashboard');
-  };
+  const handleBackToDashboard = useSmartBack();
 
   if (loading || profileLoading) {
     return (

--- a/src/pages/SleepSchedule.tsx
+++ b/src/pages/SleepSchedule.tsx
@@ -12,6 +12,7 @@ import {
   Plus
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { useSleepSchedule } from '@/hooks/useSleepSchedule';
 import { SleepScheduleSetup } from '@/components/sleep-schedule/SleepScheduleSetup';
@@ -60,9 +61,7 @@ const SleepSchedule = () => {
     navigate('/');
   };
 
-  const handleBackToDashboard = () => {
-    navigate('/dashboard');
-  };
+  const handleBackToDashboard = useSmartBack();
 
   const handleAddProfile = () => {
     setShowProfileManagement(true);

--- a/src/pages/Sounds.tsx
+++ b/src/pages/Sounds.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Volume2, ArrowLeft, Baby, Plus, BookOpen } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { useBabyProfile } from '@/hooks/useBabyProfile';
 import { ResponsiveSoundsLibrary } from '@/components/sounds/ResponsiveSoundsLibrary';
 import { SleepArticles } from '@/components/sleep-schedule/SleepArticles';
@@ -29,6 +30,7 @@ const Sounds = () => {
     loading: profileLoading
   } = useBabyProfile();
   const navigate = useNavigate();
+  const handleBackToDashboard = useSmartBack();
   const {
     t
   } = useTranslation();
@@ -43,10 +45,6 @@ const Sounds = () => {
   const handleSignOut = async () => {
     await signOut();
     navigate('/');
-  };
-
-  const handleBackToDashboard = () => {
-    navigate('/dashboard');
   };
 
   const handleAddProfile = () => {

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Moon, ArrowLeft, Check, Shield, Mail, HelpCircle } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { SubscriptionPlans } from '@/components/subscription/SubscriptionPlans';
 import { CurrentSubscriptionCard } from '@/components/subscription/CurrentSubscriptionCard';
 import { DesktopHeader } from '@/components/layout/DesktopHeader';
@@ -17,6 +18,7 @@ const Subscription = () => {
   const { user, loading } = useAuth();
   const { checkSubscription } = useSubscription();
   const navigate = useNavigate();
+  const goBack = useSmartBack();
   const { t } = useTranslation();
 
   // Always refresh subscription state when landing on this page (e.g., returning from Stripe)
@@ -70,12 +72,12 @@ const Subscription = () => {
         <div className="mb-6">
           <Button
             variant="ghost"
-            onClick={() => navigate('/dashboard')}
+            onClick={goBack}
             className="mb-4 -ml-2 text-muted-foreground hover:text-foreground"
             size="sm"
           >
             <ArrowLeft className="h-4 w-4 mr-1" />
-            {t('subscription.backToDashboard')}
+            {t('common.back', 'Back')}
           </Button>
 
           <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground tracking-tight">

--- a/src/pages/TrackActivity.tsx
+++ b/src/pages/TrackActivity.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
+import { useSmartBack } from '@/hooks/useSmartBack';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -38,6 +39,7 @@ import { TranslationWrapper } from '@/components/TranslationWrapper';
 const TrackActivity = () => {
   const { user, loading } = useAuth();
   const navigate = useNavigate();
+  const goBack = useSmartBack();
   const { activeProfile, profiles, loading: profileLoading, switching, createProfile } = useBabyProfile();
   const { logs, loading: logsLoading, deleteLog, updateLog, refetchLogs } = useActivityLogs(activeProfile?.id || '');
   const { permissions, role, loading: permissionsLoading } = useProfilePermissions(activeProfile?.id || null);
@@ -88,9 +90,9 @@ const TrackActivity = () => {
       <TranslationWrapper>
         <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5">
           <div className="max-w-2xl mx-auto px-4 py-4 sm:py-8">
-            <Button 
-              variant="ghost" 
-              onClick={() => navigate('/dashboard')}
+            <Button
+              variant="ghost"
+              onClick={goBack}
               className="mb-4 sm:mb-6 hover:bg-primary/10"
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
@@ -111,9 +113,9 @@ const TrackActivity = () => {
           <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-6 sm:mb-8 space-y-4 sm:space-y-0">
           <div className="flex-1">
               <div className="mb-4">
-                <Button 
-                  variant="ghost" 
-                  onClick={() => navigate('/dashboard')}
+                <Button
+                  variant="ghost"
+                  onClick={goBack}
                   size={isMobile ? "sm" : "default"}
                   className="hover:bg-primary/10"
                 >

--- a/src/utils/generateUserDataExport.ts
+++ b/src/utils/generateUserDataExport.ts
@@ -1,0 +1,425 @@
+import jsPDF from "jspdf";
+
+// Shape returned by the export-user-data edge function (loosely typed —
+// we just render what's present without assuming every field exists).
+export interface ExportData {
+  export_version?: string;
+  exported_at?: string;
+  account?: {
+    id?: string;
+    email?: string;
+    created_at?: string;
+    last_sign_in_at?: string;
+    user_metadata?: Record<string, any>;
+  };
+  profile?: any;
+  babies?: any[];
+  baby_activities?: any[];
+  baby_memories?: any[];
+  sleep_schedules?: any[];
+  family?: {
+    memberships?: any[];
+    members_invited_by_me?: any[];
+    invitations_sent?: any[];
+    invitations_received?: any[];
+    messages_sent?: any[];
+    message_participations?: any[];
+  };
+  chat?: { conversations?: any[]; messages?: any[] };
+  subscriptions?: any[];
+  notifications?: {
+    settings?: any[];
+    push_subscriptions?: any[];
+    scheduled?: any[];
+  };
+  activity?: {
+    user_queries?: any[];
+    user_locations?: any[];
+    security_events?: any[];
+    user_sessions?: any[];
+  };
+  newsletter_subscribers?: any[];
+}
+
+const PAGE = { width: 595.28, height: 841.89, margin: 40 };
+const COLORS = {
+  primary: [99, 102, 241] as [number, number, number],
+  text: [31, 41, 55] as [number, number, number],
+  muted: [107, 114, 128] as [number, number, number],
+  light: [243, 244, 246] as [number, number, number],
+  border: [229, 231, 235] as [number, number, number],
+  accent: [16, 185, 129] as [number, number, number],
+};
+
+function formatDate(d?: string | null): string {
+  if (!d) return "—";
+  try {
+    return new Date(d).toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return String(d);
+  }
+}
+
+function formatShortDate(d?: string | null): string {
+  if (!d) return "—";
+  try {
+    return new Date(d).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return String(d);
+  }
+}
+
+function formatActivityType(type?: string): string {
+  if (!type) return "—";
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function formatDuration(minutes?: number | null): string {
+  if (minutes == null) return "—";
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+export function generateUserDataPDF(data: ExportData, filename?: string): void {
+  const doc = new jsPDF({ unit: "pt", format: "a4" });
+  const totalPagesPlaceholder = "{TOTAL_PAGES}";
+  let y = PAGE.margin;
+  let pageNumber = 1;
+
+  const drawFooter = () => {
+    doc.setFontSize(9);
+    doc.setTextColor(...COLORS.muted);
+    doc.setFont("helvetica", "normal");
+    doc.text(
+      "Sleepy Babyy — personal data export",
+      PAGE.margin,
+      PAGE.height - 20,
+    );
+    doc.text(
+      `Page ${pageNumber} of ${totalPagesPlaceholder}`,
+      PAGE.width - PAGE.margin,
+      PAGE.height - 20,
+      { align: "right" },
+    );
+  };
+
+  const ensureSpace = (needed: number) => {
+    if (y + needed > PAGE.height - PAGE.margin - 30) {
+      drawFooter();
+      doc.addPage();
+      pageNumber++;
+      y = PAGE.margin;
+    }
+  };
+
+  const addHeading = (text: string) => {
+    ensureSpace(50);
+    doc.setFillColor(...COLORS.primary);
+    doc.rect(PAGE.margin, y, PAGE.width - PAGE.margin * 2, 28, "F");
+    doc.setTextColor(255, 255, 255);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(13);
+    doc.text(text, PAGE.margin + 12, y + 19);
+    y += 38;
+  };
+
+  const addSubtitle = (text: string) => {
+    ensureSpace(20);
+    doc.setTextColor(...COLORS.muted);
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(10);
+    doc.text(text, PAGE.margin, y);
+    y += 16;
+  };
+
+  const addKeyValueRow = (label: string, value: string) => {
+    ensureSpace(18);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10);
+    doc.setTextColor(...COLORS.text);
+    doc.text(label, PAGE.margin, y);
+    doc.setFont("helvetica", "normal");
+    doc.setTextColor(...COLORS.text);
+    const wrapped = doc.splitTextToSize(value || "—", PAGE.width - PAGE.margin * 2 - 130);
+    doc.text(wrapped, PAGE.margin + 130, y);
+    y += 14 * Math.max(wrapped.length, 1) + 4;
+  };
+
+  const addNote = (text: string) => {
+    ensureSpace(16);
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(9);
+    doc.setTextColor(...COLORS.muted);
+    doc.text(text, PAGE.margin, y);
+    y += 14;
+  };
+
+  const addEmptyRow = (label: string) => {
+    addNote(`No ${label} on file.`);
+    y += 6;
+  };
+
+  const addTable = (
+    columns: { header: string; key: string; width: number; format?: (v: any, row: any) => string }[],
+    rows: any[],
+    maxRows: number = 50,
+  ) => {
+    const colTotal = columns.reduce((s, c) => s + c.width, 0);
+    const usableWidth = PAGE.width - PAGE.margin * 2;
+    const scale = usableWidth / colTotal;
+
+    const headerHeight = 22;
+    const rowHeight = 16;
+
+    ensureSpace(headerHeight + rowHeight + 10);
+
+    // Header
+    let x = PAGE.margin;
+    doc.setFillColor(...COLORS.light);
+    doc.rect(PAGE.margin, y, usableWidth, headerHeight, "F");
+    doc.setTextColor(...COLORS.text);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(9);
+    for (const col of columns) {
+      doc.text(col.header, x + 6, y + 14);
+      x += col.width * scale;
+    }
+    y += headerHeight;
+
+    // Rows
+    const shown = rows.slice(0, maxRows);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    for (let i = 0; i < shown.length; i++) {
+      ensureSpace(rowHeight + 4);
+      if (i % 2 === 1) {
+        doc.setFillColor(249, 250, 251);
+        doc.rect(PAGE.margin, y, usableWidth, rowHeight, "F");
+      }
+      x = PAGE.margin;
+      doc.setTextColor(...COLORS.text);
+      for (const col of columns) {
+        const formatted = col.format
+          ? col.format(shown[i][col.key], shown[i])
+          : shown[i][col.key] ?? "—";
+        const raw = String(formatted);
+        const maxChars = Math.floor((col.width * scale - 12) / 4.5);
+        const text = raw.length > maxChars ? raw.slice(0, maxChars - 1) + "…" : raw;
+        doc.text(text, x + 6, y + 11);
+        x += col.width * scale;
+      }
+      y += rowHeight;
+    }
+
+    if (rows.length > maxRows) {
+      y += 4;
+      addNote(`Showing ${maxRows} of ${rows.length} entries — full data is in the JSON export.`);
+    }
+    y += 10;
+  };
+
+  // === Cover ===
+  doc.setFillColor(...COLORS.primary);
+  doc.rect(0, 0, PAGE.width, 120, "F");
+  doc.setTextColor(255, 255, 255);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(24);
+  doc.text("My Sleepy Babyy Data", PAGE.margin, 60);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(11);
+  doc.text("A copy of everything we store about your account.", PAGE.margin, 85);
+  y = 150;
+
+  // === Account section ===
+  addHeading("Account");
+  addKeyValueRow("Email:", data.account?.email ?? "—");
+  addKeyValueRow("Full name:", data.account?.user_metadata?.full_name ?? data.profile?.full_name ?? "—");
+  addKeyValueRow("Account ID:", data.account?.id ?? "—");
+  addKeyValueRow("Account created:", formatDate(data.account?.created_at));
+  addKeyValueRow("Last sign in:", formatDate(data.account?.last_sign_in_at));
+  addKeyValueRow("Export generated:", formatDate(data.exported_at ?? new Date().toISOString()));
+  y += 8;
+
+  // === Babies ===
+  addHeading("Baby Profiles");
+  const babies = data.babies ?? [];
+  if (babies.length === 0) {
+    addEmptyRow("baby profiles");
+  } else {
+    addTable(
+      [
+        { header: "Name", key: "name", width: 30 },
+        { header: "Birth Date", key: "birth_date", width: 25, format: (v) => formatShortDate(v) },
+        { header: "Created", key: "created_at", width: 25, format: (v) => formatShortDate(v) },
+        { header: "Active", key: "is_active", width: 20, format: (v) => (v ? "Yes" : "No") },
+      ],
+      babies,
+    );
+  }
+
+  // === Activities ===
+  addHeading("Activities");
+  const activities = (data.baby_activities ?? []).slice().sort(
+    (a: any, b: any) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime(),
+  );
+  addSubtitle(`Total recorded: ${activities.length}`);
+  if (activities.length === 0) {
+    addEmptyRow("activities");
+  } else {
+    addTable(
+      [
+        { header: "Type", key: "activity_type", width: 22, format: (v) => formatActivityType(v) },
+        { header: "Start", key: "start_time", width: 38, format: (v) => formatDate(v) },
+        { header: "Duration", key: "duration_minutes", width: 20, format: (v) => formatDuration(v) },
+        { header: "Notes", key: "notes", width: 40, format: (v) => v ?? "—" },
+      ],
+      activities,
+      40,
+    );
+  }
+
+  // === Sleep schedules ===
+  addHeading("Sleep Schedules");
+  const schedules = data.sleep_schedules ?? [];
+  if (schedules.length === 0) {
+    addEmptyRow("saved sleep schedules");
+  } else {
+    addTable(
+      [
+        { header: "Child Age", key: "child_age", width: 20, format: (v) => `${v ?? "—"} months` },
+        { header: "Bedtime", key: "current_bedtime", width: 25 },
+        { header: "Wake Time", key: "current_wake_time", width: 25 },
+        { header: "Sleep Hours", key: "total_sleep_hours", width: 25, format: (v) => v ?? "—" },
+        { header: "Saved", key: "created_at", width: 25, format: (v) => formatShortDate(v) },
+      ],
+      schedules,
+    );
+  }
+
+  // === Memories ===
+  addHeading("Photo & Video Memories");
+  const memories = data.baby_memories ?? [];
+  if (memories.length === 0) {
+    addEmptyRow("memories");
+  } else {
+    addTable(
+      [
+        { header: "Title", key: "title", width: 35, format: (v) => v ?? "(untitled)" },
+        { header: "Type", key: "media_type", width: 15 },
+        { header: "Taken", key: "taken_at", width: 25, format: (v) => formatShortDate(v) },
+        { header: "Uploaded", key: "created_at", width: 25, format: (v) => formatShortDate(v) },
+      ],
+      memories,
+    );
+  }
+
+  // === Family sharing ===
+  addHeading("Family Sharing");
+  const memberships = data.family?.memberships ?? [];
+  const invitedByMe = data.family?.members_invited_by_me ?? [];
+  const invSent = data.family?.invitations_sent ?? [];
+  const invReceived = data.family?.invitations_received ?? [];
+  addKeyValueRow("My memberships:", String(memberships.length));
+  addKeyValueRow("People I invited (joined):", String(invitedByMe.length));
+  addKeyValueRow("Invitations I sent:", String(invSent.length));
+  addKeyValueRow("Invitations I received:", String(invReceived.length));
+  y += 8;
+
+  // === Subscriptions ===
+  addHeading("Subscription & Billing");
+  const subs = data.subscriptions ?? [];
+  if (subs.length === 0) {
+    addEmptyRow("subscriptions");
+  } else {
+    addTable(
+      [
+        { header: "Plan", key: "subscription_tier", width: 25 },
+        { header: "Status", key: "status", width: 20 },
+        { header: "Billing", key: "billing_cycle", width: 20 },
+        { header: "Period ends", key: "current_period_end", width: 30, format: (v) => formatShortDate(v) },
+        { header: "Trial?", key: "is_trial", width: 15, format: (v) => (v ? "Yes" : "No") },
+      ],
+      subs,
+    );
+  }
+
+  // === Notification settings ===
+  addHeading("Notification Settings");
+  const notif = data.notifications?.settings ?? [];
+  if (notif.length === 0) {
+    addEmptyRow("notification settings");
+  } else {
+    const n = notif[0] ?? {};
+    addKeyValueRow("Notifications enabled:", n.notifications_enabled ? "Yes" : "No");
+    addKeyValueRow("Feeding reminders:", n.feeding_reminders ? "Yes" : "No");
+    addKeyValueRow("Sleep reminders:", n.sleep_reminders ? "Yes" : "No");
+    addKeyValueRow("Milestone reminders:", n.milestone_reminders ? "Yes" : "No");
+    addKeyValueRow("Pattern alerts:", n.pattern_alerts ? "Yes" : "No");
+    addKeyValueRow("Quiet hours:", n.quiet_hours_enabled ? `${n.quiet_hours_start} – ${n.quiet_hours_end}` : "Off");
+    y += 8;
+  }
+  addKeyValueRow("Push subscriptions registered:", String(data.notifications?.push_subscriptions?.length ?? 0));
+  addKeyValueRow("Scheduled notifications stored:", String(data.notifications?.scheduled?.length ?? 0));
+  y += 8;
+
+  // === Chat assistant ===
+  addHeading("Chat Assistant History");
+  addKeyValueRow("Conversations:", String(data.chat?.conversations?.length ?? 0));
+  addKeyValueRow("Messages:", String(data.chat?.messages?.length ?? 0));
+  addNote("Full chat history is included in the JSON export if you need it.");
+  y += 8;
+
+  // === Activity / security ===
+  addHeading("Account Activity");
+  addKeyValueRow("Sign-in / security events:", String(data.activity?.security_events?.length ?? 0));
+  addKeyValueRow("Tracked sessions:", String(data.activity?.user_sessions?.length ?? 0));
+  addKeyValueRow("Support queries sent:", String(data.activity?.user_queries?.length ?? 0));
+  addKeyValueRow("Location records:", String(data.activity?.user_locations?.length ?? 0));
+  y += 8;
+
+  // === Footer page ===
+  ensureSpace(60);
+  doc.setDrawColor(...COLORS.border);
+  doc.line(PAGE.margin, y, PAGE.width - PAGE.margin, y);
+  y += 14;
+  doc.setFont("helvetica", "italic");
+  doc.setFontSize(9);
+  doc.setTextColor(...COLORS.muted);
+  const disclaimer = doc.splitTextToSize(
+    "This document is a human-readable summary of your data. If you want the complete raw data (including chat messages, full activity log, and metadata), you can request a JSON export — contact support or use the developer export option.",
+    PAGE.width - PAGE.margin * 2,
+  );
+  doc.text(disclaimer, PAGE.margin, y);
+
+  drawFooter();
+
+  // Substitute total page count on every page footer
+  const total = (doc as any).getNumberOfPages();
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    doc.setFontSize(9);
+    doc.setTextColor(...COLORS.muted);
+    doc.setFillColor(255, 255, 255);
+    doc.rect(PAGE.width - PAGE.margin - 80, PAGE.height - 30, 80, 14, "F");
+    doc.text(`Page ${i} of ${total}`, PAGE.width - PAGE.margin, PAGE.height - 20, { align: "right" });
+  }
+
+  const finalName =
+    filename ??
+    `sleepybabyy-data-${(data.account?.id ?? "user").slice(0, 8)}-${new Date()
+      .toISOString()
+      .slice(0, 10)}.pdf`;
+  doc.save(finalName);
+}

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,8 +1,6 @@
-
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js";
 
-// Setup Supabase admin client
 const supabase = createClient(
   Deno.env.get("SUPABASE_URL")!,
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
@@ -13,13 +11,20 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
+async function safeDelete(label: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+  } catch (e) {
+    console.error(`[delete-account] step "${label}" failed`, e);
+  }
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    // Auth check - get the JWT
     const authHeader = req.headers.get("Authorization") ?? "";
     const token = authHeader.replace("Bearer ", "").trim();
     if (!token) {
@@ -29,7 +34,6 @@ serve(async (req) => {
       });
     }
 
-    // Get user from token
     const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
     if (userErr || !user) {
       return new Response(JSON.stringify({ error: "Invalid user or session. Please re-login." }), {
@@ -38,29 +42,67 @@ serve(async (req) => {
       });
     }
     const user_id = user.id;
+    const user_email = user.email ?? null;
 
-    // Delete related tables first (order matters to avoid foreign key issues)
-    await supabase.from("family_members").delete().eq("user_id", user_id);
-    await supabase.from("family_invitations").delete().eq("invited_by", user_id);
-    await supabase.from("baby_memories").delete().eq("user_id", user_id);
+    // Collect owned baby ids (their child rows must be removed first)
+    const { data: babies } = await supabase.from("baby_profiles").select("id").eq("user_id", user_id);
+    const babyIds: string[] = (babies ?? []).map((b: { id: string }) => b.id);
 
-    // Get all owned baby profiles; delete their activities and then the profiles themselves
-    const { data: babies, error: babyListErr } = await supabase.from("baby_profiles").select("id").eq("user_id", user_id);
-    if (!babyListErr && babies) {
-      for (const baby of babies) {
-        await supabase.from("baby_activities").delete().eq("baby_id", baby.id);
-        await supabase.from("sleep_schedules").delete().eq("baby_id", baby.id);
-      }
-      await supabase.from("baby_profiles").delete().eq("user_id", user_id);
+    // Collect owned chat conversation ids (chat_messages reference them)
+    const { data: convs } = await supabase.from("chat_conversations").select("id").eq("user_id", user_id);
+    const convIds: string[] = (convs ?? []).map((c: { id: string }) => c.id);
+
+    // Step A — child rows of owned babies
+    if (babyIds.length > 0) {
+      await safeDelete("baby_activities", () => supabase.from("baby_activities").delete().in("baby_id", babyIds));
+      await safeDelete("sleep_schedules", () => supabase.from("sleep_schedules").delete().in("baby_id", babyIds));
+      await safeDelete("family_members(by baby)", () => supabase.from("family_members").delete().in("baby_id", babyIds));
+      await safeDelete("family_invitations(by baby)", () => supabase.from("family_invitations").delete().in("baby_id", babyIds));
+      await safeDelete("scheduled_notifications(by baby)", () => supabase.from("scheduled_notifications").delete().in("baby_id", babyIds));
+      await safeDelete("family_messages(by baby)", () => supabase.from("family_messages").delete().in("baby_id", babyIds));
     }
 
-    // Delete subscriptions
-    await supabase.from("subscriptions").delete().eq("user_id", user_id);
+    // Step B — chat data
+    if (convIds.length > 0) {
+      await safeDelete("chat_messages", () => supabase.from("chat_messages").delete().in("conversation_id", convIds));
+    }
+    await safeDelete("chat_conversations", () => supabase.from("chat_conversations").delete().eq("user_id", user_id));
 
-    // Delete their profile row if present
-    await supabase.from("profiles").delete().eq("id", user_id);
+    // Step C — direct user references
+    await safeDelete("family_members(by user)", () => supabase.from("family_members").delete().eq("user_id", user_id));
+    await safeDelete("family_members(invited_by)", () => supabase.from("family_members").delete().eq("invited_by", user_id));
+    await safeDelete("family_invitations(invited_by)", () => supabase.from("family_invitations").delete().eq("invited_by", user_id));
+    if (user_email) {
+      await safeDelete("family_invitations(by email)", () => supabase.from("family_invitations").delete().eq("email", user_email));
+    }
+    await safeDelete("family_messages(by sender)", () => supabase.from("family_messages").delete().eq("sender_id", user_id));
+    await safeDelete("message_participants", () => supabase.from("message_participants").delete().eq("user_id", user_id));
+    await safeDelete("baby_memories", () => supabase.from("baby_memories").delete().eq("user_id", user_id));
+    await safeDelete("baby_profiles", () => supabase.from("baby_profiles").delete().eq("user_id", user_id));
+    await safeDelete("subscriptions", () => supabase.from("subscriptions").delete().eq("user_id", user_id));
+    await safeDelete("user_queries", () => supabase.from("user_queries").delete().eq("user_id", user_id));
+    await safeDelete("user_locations", () => supabase.from("user_locations").delete().eq("user_id", user_id));
+    await safeDelete("push_subscriptions", () => supabase.from("push_subscriptions").delete().eq("user_id", user_id));
+    await safeDelete("scheduled_notifications", () => supabase.from("scheduled_notifications").delete().eq("user_id", user_id));
+    await safeDelete("security_events", () => supabase.from("security_events").delete().eq("user_id", user_id));
+    await safeDelete("user_sessions", () => supabase.from("user_sessions").delete().eq("user_id", user_id));
+    await safeDelete("notification_settings", () => supabase.from("notification_settings").delete().eq("user_id", user_id));
+    await safeDelete("marketing_events", () => supabase.from("marketing_events").delete().eq("user_id", user_id));
 
-    // Finally, delete the user from auth
+    // Anonymise admin reply attribution (preserve the customer messages themselves)
+    await safeDelete("contact_messages(replied_by null)", () =>
+      supabase.from("contact_messages").update({ replied_by: null }).eq("replied_by", user_id)
+    );
+
+    if (user_email) {
+      await safeDelete("newsletter_subscribers", () => supabase.from("newsletter_subscribers").delete().eq("email", user_email));
+      await safeDelete("password_reset_codes", () => supabase.from("password_reset_codes").delete().eq("email", user_email));
+    }
+
+    // Profile row last (FK -> auth.users)
+    await safeDelete("profiles", () => supabase.from("profiles").delete().eq("id", user_id));
+
+    // Finally, the auth user
     const { error: deleteErr } = await supabase.auth.admin.deleteUser(user_id);
     if (deleteErr) {
       return new Response(JSON.stringify({ error: "Failed to delete user from auth: " + deleteErr.message }), {

--- a/supabase/functions/export-user-data/index.ts
+++ b/supabase/functions/export-user-data/index.ts
@@ -1,0 +1,162 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+async function safeSelect<T>(label: string, fn: () => Promise<{ data: T | null }>): Promise<T | null> {
+  try {
+    const { data } = await fn();
+    return data ?? null;
+  } catch (e) {
+    console.error(`[export-user-data] read "${label}" failed`, e);
+    return null;
+  }
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const token = authHeader.replace("Bearer ", "").trim();
+    if (!token) {
+      return new Response(JSON.stringify({ error: "Not authenticated" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
+    if (userErr || !user) {
+      return new Response(JSON.stringify({ error: "Invalid user or session. Please re-login." }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const user_id = user.id;
+    const user_email = user.email ?? null;
+
+    const babies = await safeSelect("baby_profiles", () =>
+      supabase.from("baby_profiles").select("*").eq("user_id", user_id)
+    ) as Array<{ id: string }> | null;
+    const babyIds = (babies ?? []).map((b) => b.id);
+
+    const convs = await safeSelect("chat_conversations", () =>
+      supabase.from("chat_conversations").select("*").eq("user_id", user_id)
+    ) as Array<{ id: string }> | null;
+    const convIds = (convs ?? []).map((c) => c.id);
+
+    const [
+      profile,
+      babyActivities,
+      babyMemories,
+      sleepSchedules,
+      familyMembers,
+      familyMembersInvitedBy,
+      familyInvitationsByUser,
+      familyInvitationsByEmail,
+      familyMessages,
+      messageParticipants,
+      chatMessages,
+      subscriptions,
+      userQueries,
+      userLocations,
+      pushSubscriptions,
+      scheduledNotifications,
+      securityEvents,
+      userSessions,
+      notificationSettings,
+      newsletterSubscribers,
+    ] = await Promise.all([
+      safeSelect("profile", () => supabase.from("profiles").select("*").eq("id", user_id).maybeSingle()),
+      babyIds.length ? safeSelect("baby_activities", () => supabase.from("baby_activities").select("*").in("baby_id", babyIds)) : Promise.resolve([]),
+      safeSelect("baby_memories", () => supabase.from("baby_memories").select("*").eq("user_id", user_id)),
+      babyIds.length ? safeSelect("sleep_schedules", () => supabase.from("sleep_schedules").select("*").in("baby_id", babyIds)) : Promise.resolve([]),
+      safeSelect("family_members", () => supabase.from("family_members").select("*").eq("user_id", user_id)),
+      safeSelect("family_members_invited_by", () => supabase.from("family_members").select("*").eq("invited_by", user_id)),
+      safeSelect("family_invitations_by_user", () => supabase.from("family_invitations").select("*").eq("invited_by", user_id)),
+      user_email ? safeSelect("family_invitations_by_email", () => supabase.from("family_invitations").select("*").eq("email", user_email)) : Promise.resolve([]),
+      safeSelect("family_messages", () => supabase.from("family_messages").select("*").eq("sender_id", user_id)),
+      safeSelect("message_participants", () => supabase.from("message_participants").select("*").eq("user_id", user_id)),
+      convIds.length ? safeSelect("chat_messages", () => supabase.from("chat_messages").select("*").in("conversation_id", convIds)) : Promise.resolve([]),
+      safeSelect("subscriptions", () => supabase.from("subscriptions").select("*").eq("user_id", user_id)),
+      safeSelect("user_queries", () => supabase.from("user_queries").select("*").eq("user_id", user_id)),
+      safeSelect("user_locations", () => supabase.from("user_locations").select("*").eq("user_id", user_id)),
+      safeSelect("push_subscriptions", () => supabase.from("push_subscriptions").select("*").eq("user_id", user_id)),
+      safeSelect("scheduled_notifications", () => supabase.from("scheduled_notifications").select("*").eq("user_id", user_id)),
+      safeSelect("security_events", () => supabase.from("security_events").select("*").eq("user_id", user_id)),
+      safeSelect("user_sessions", () => supabase.from("user_sessions").select("*").eq("user_id", user_id)),
+      safeSelect("notification_settings", () => supabase.from("notification_settings").select("*").eq("user_id", user_id)),
+      user_email ? safeSelect("newsletter_subscribers", () => supabase.from("newsletter_subscribers").select("*").eq("email", user_email)) : Promise.resolve([]),
+    ]);
+
+    const exportData = {
+      export_version: "1.0",
+      exported_at: new Date().toISOString(),
+      account: {
+        id: user.id,
+        email: user.email,
+        created_at: user.created_at,
+        last_sign_in_at: user.last_sign_in_at,
+        user_metadata: user.user_metadata,
+      },
+      profile,
+      babies: babies ?? [],
+      baby_activities: babyActivities ?? [],
+      baby_memories: babyMemories ?? [],
+      sleep_schedules: sleepSchedules ?? [],
+      family: {
+        memberships: familyMembers ?? [],
+        members_invited_by_me: familyMembersInvitedBy ?? [],
+        invitations_sent: familyInvitationsByUser ?? [],
+        invitations_received: familyInvitationsByEmail ?? [],
+        messages_sent: familyMessages ?? [],
+        message_participations: messageParticipants ?? [],
+      },
+      chat: {
+        conversations: convs ?? [],
+        messages: chatMessages ?? [],
+      },
+      subscriptions: subscriptions ?? [],
+      notifications: {
+        settings: notificationSettings ?? [],
+        push_subscriptions: pushSubscriptions ?? [],
+        scheduled: scheduledNotifications ?? [],
+      },
+      activity: {
+        user_queries: userQueries ?? [],
+        user_locations: userLocations ?? [],
+        security_events: securityEvents ?? [],
+        user_sessions: userSessions ?? [],
+      },
+      newsletter_subscribers: newsletterSubscribers ?? [],
+    };
+
+    const filename = `sleepybabyy-data-${user_id.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.json`;
+
+    return new Response(JSON.stringify(exportData, null, 2), {
+      status: 200,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    console.error("Export user data error", err);
+    return new Response(JSON.stringify({ error: "An error occurred while exporting your data." }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
- Add useSmartBack hook that returns to actual previous in-app page (uses history.state.idx instead of location.key) and apply it consistently across Account, Contact, FamilySharing, HelpCenter, Memories, Notifications, PediatricianReports, Reports, SleepSchedule, Sounds, Subscription, TrackActivity, Features
- Redesign Contact and HelpCenter with consistent pink/purple/indigo gradient palette matching the rest of the app
- Add live search to HelpCenter (filters categories + articles, Enter-to-submit, clear button, no-results state, mobile responsive)
- Replace /security route with redirect to /account?tab=security
- Add user data export: edge function plus client-side PDF generator
- Strengthen delete-account cleanup with broader table coverage and per-step error isolation