### PR TITLE
Fix delete-account redirecting to onboarding instead of signing out

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -346,17 +346,22 @@ const Account = () => {
         title: "Account Deleted",
         description: "Your account and all data were deleted.",
       });
-      setTimeout(() => {
-        signOut();
-        window.location.href = "/";
-      }, 1500);
+
+      // Sign out IMMEDIATELY before any redirect logic runs.
+      // OnboardingGate watches the user object — if we leave the user
+      // signed in even briefly, it sees a logged-in user whose profile
+      // row no longer exists and force-redirects to /onboarding, which
+      // traps the user. Awaiting signOut clears the auth state first,
+      // then a hard reload to "/" wipes all in-memory state.
+      try { await signOut(); } catch { /* ignore — we're navigating away */ }
+      window.location.replace("/");
+      return;
     } catch (err: any) {
       toast({
         title: "Error",
         description: err.message || "Failed to delete account",
         variant: "destructive",
       });
-    } finally {
       setDeleting(false);
       setShowDeleteDialog(false);
       setDeleteConfirm("");


### PR DESCRIPTION
After the edge function deleted the user's data, the frontend used a 1.5s setTimeout before calling signOut() (without await) and redirecting. During that delay the user object was still in React state but the profile row was already gone, so OnboardingGate saw "logged-in user without profile" and force-redirected to /onboarding via replace, trapping the user on a page they couldn't escape.

Now signOut runs synchronously (awaited) right after the success toast, which clears auth state before any gate can react, followed by a hard window.location.replace("/") to wipe in-memory state. The dialog state cleanup moved into the catch block since the success path navigates away.