### PR TITLE
Fix mobile email button on Careers and add scroll-to-top on landing

### DIFF
--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -168,12 +168,16 @@ const Careers = () => {
                     </p>
                     <a
                       href={`mailto:${SUPPORT_EMAIL}?subject=Future%20careers%20%E2%80%94%20introduction&body=Hi%20SleepyBabyy%20team%2C%0A%0AA%20bit%20about%20me%3A%0A%0AWhat%20excites%20me%20about%20what%20you%27re%20building%3A%0A%0AHow%20to%20reach%20me%3A%0A%0AThanks%21`}
-                      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white text-sm font-semibold shadow-md shadow-purple-500/30 hover:shadow-lg hover:scale-[1.02] transition-all touch-target"
+                      className="flex sm:inline-flex w-full sm:w-auto items-center justify-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white text-sm font-semibold shadow-md shadow-purple-500/30 hover:shadow-lg hover:scale-[1.02] transition-all touch-target"
                     >
-                      <Mail className="h-4 w-4" />
-                      Email us — {SUPPORT_EMAIL}
-                      <ArrowRight className="h-4 w-4" />
+                      <Mail className="h-4 w-4 flex-shrink-0" />
+                      <span className="hidden sm:inline truncate">Email us — {SUPPORT_EMAIL}</span>
+                      <span className="sm:hidden">Email us</span>
+                      <ArrowRight className="h-4 w-4 flex-shrink-0" />
                     </a>
+                    <p className="sm:hidden text-xs text-gray-500 mt-2 break-all">
+                      {SUPPORT_EMAIL}
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useTranslation } from "react-i18next";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { SubscriptionPlans } from "@/components/subscription/SubscriptionPlans";
-import { Clock, Calendar, Volume2, Users, BarChart3, Star, Heart, CheckCircle, Play, Globe, Check, Crown, Badge, Menu, X, ArrowRight, Sparkles, Moon, Sun, Award, TrendingUp, Shield, Zap } from "lucide-react";
+import { Clock, Calendar, Volume2, Users, BarChart3, Star, Heart, CheckCircle, Play, Globe, Check, Crown, Badge, Menu, X, ArrowRight, ArrowUp, Sparkles, Moon, Sun, Award, TrendingUp, Shield, Zap } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { memo, useMemo, useState, useEffect, useRef, useCallback } from "react";
 import CountUp from "@/components/CountUp";
@@ -203,8 +203,21 @@ const Index = () => {
   } = useToast();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [heroVideoPlaying, setHeroVideoPlaying] = useState(false);
+  const [showScrollTop, setShowScrollTop] = useState(false);
   const heroVideoRef = useRef<HTMLVideoElement>(null);
   const { openPreferences } = useCookieConsent();
+
+  // Show "scroll to top" floating button once the user has scrolled past the fold
+  useEffect(() => {
+    const onScroll = () => setShowScrollTop(window.scrollY > 400);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
   const handleGetStarted = () => {
     if (user) {
       navigate('/dashboard');
@@ -983,7 +996,18 @@ const Index = () => {
           </div>
         </div>
       </footer>
-     
+
+      {/* Scroll-to-top floating button — shows after user scrolls past the fold */}
+      <button
+        type="button"
+        onClick={scrollToTop}
+        aria-label="Back to top"
+        className={`fixed bottom-6 right-6 sm:bottom-8 sm:right-8 z-50 h-12 w-12 sm:h-14 sm:w-14 rounded-full bg-gradient-to-br from-pink-500 via-purple-500 to-indigo-500 text-white shadow-lg shadow-purple-500/40 hover:shadow-xl hover:shadow-purple-500/50 hover:scale-110 active:scale-95 transition-all duration-300 flex items-center justify-center ${
+          showScrollTop ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 translate-y-4 pointer-events-none'
+        }`}
+      >
+        <ArrowUp className="h-5 w-5 sm:h-6 sm:w-6" />
+      </button>
    </div>;
 };
 export default Index;


### PR DESCRIPTION
- Careers: email CTA now full-width on mobile with shortened label; full address shown below for readability (was overflowing on small screens)
- Index: floating scroll-to-top button (ArrowUp, pink/purple/indigo gradient) appears after 400px scroll, smooth-scrolls to top on click